### PR TITLE
fix: run shutdown callbacks before non-critical cleanup

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -323,11 +323,34 @@ class _JobProc:
 
         shutdown_info = await self._shutdown_fut
 
-        # TODO(theomonnom): move this code?
+        # Close agent session first (stops audio processing)
         if session := self._job_ctx._primary_agent_session:
             await session.aclose()
 
-        await self._job_ctx._on_session_end()
+        # Run shutdown callbacks before non-critical cleanup.
+        # These callbacks handle DB updates, recording finalization, and
+        # concurrency release — operations that must complete for data integrity.
+        # Previously, callbacks ran after _on_session_end/send(Exiting)/room.disconnect,
+        # meaning any crash or hang in those steps would prevent DB finalization.
+        try:
+            shutdown_tasks = []
+            for callback in self._job_ctx._shutdown_callbacks:
+                shutdown_tasks.append(
+                    asyncio.create_task(
+                        callback(shutdown_info.reason), name="job_shutdown_callback"
+                    )
+                )
+
+            await asyncio.gather(*shutdown_tasks)
+        except Exception:
+            logger.exception("error while shutting down the job")
+
+        # Non-critical cleanup: session report, IPC notification, room disconnect.
+        # Failures here do not affect call data integrity.
+        try:
+            await self._job_ctx._on_session_end()
+        except Exception:
+            logger.exception("error in _on_session_end")
 
         if self._session_end_fnc:
             try:
@@ -341,19 +364,6 @@ class _JobProc:
         )
         await self._client.send(Exiting(reason=shutdown_info.reason))
         await self._room.disconnect()
-
-        try:
-            shutdown_tasks = []
-            for callback in self._job_ctx._shutdown_callbacks:
-                shutdown_tasks.append(
-                    asyncio.create_task(
-                        callback(shutdown_info.reason), name="job_shutdown_callback"
-                    )
-                )
-
-            await asyncio.gather(*shutdown_tasks)
-        except Exception:
-            logger.exception("error while shutting down the job")
 
         self._job_ctx._on_cleanup()
         await http_context._close_http_ctx()

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -819,8 +819,9 @@ async def run_job(
         extra={"reason": shutdown_info.reason, "user_initiated": shutdown_info.user_initiated},
     )
 
-    await room.disconnect()
-
+    # Run shutdown callbacks before room disconnect.
+    # Callbacks handle DB updates, recording finalization, and concurrency release
+    # which must complete for data integrity regardless of room disconnect outcome.
     try:
         shutdown_tasks = []
         for callback in job_ctx._shutdown_callbacks:
@@ -831,6 +832,8 @@ async def run_job(
         await asyncio.gather(*shutdown_tasks)
     except Exception:
         logger.exception("error while shutting down the job")
+
+    await room.disconnect()
 
     await http_context._close_http_ctx()
     _JobContextVar.reset(job_ctx_token)


### PR DESCRIPTION
## Summary
- Move shutdown callback execution (`handle_shutdown` -> `end_call` -> DB update) **before** `_on_session_end`, `send(Exiting)`, and `room.disconnect()`
- Wrap `_on_session_end()` in try/except (was previously unprotected)
- Fix applied to both process-based (`job_proc_lazy_main.py`) and thread-based (`job.py`) executors

## Problem
Production call `f6e8aeae` was stuck in `ongoing` status with no `end_at` or `disconnection_reason`. Root cause: permanent agent transfer (transferAgent) left the AgentSession in an inconsistent state. When the caller hung up, `session.aclose()` completed but `_on_session_end()` crashed, killing the process before shutdown callbacks could execute.

The shutdown callbacks contain critical operations:
- `handle_shutdown` -> `end_call` (DB status update, recording finalization)
- Concurrency slot release
- Room deletion

These were positioned **after** non-critical operations (`_on_session_end`, `send(Exiting)`, `room.disconnect`), meaning any failure in those steps prevented DB finalization.

## Before / After

| Order | Before | After |
|-------|--------|-------|
| 1 | session.aclose() | session.aclose() |
| 2 | _on_session_end() (no try/except) | **shutdown_callbacks** (moved up) |
| 3 | send(Exiting) | _on_session_end() + try/except |
| 4 | room.disconnect() | send(Exiting) |
| 5 | shutdown_callbacks | room.disconnect() |

## Test plan
- [ ] Deploy to staging and run inbound + outbound calls with normal disconnect
- [ ] Test permanent agent transfer (transferAgent) flow with caller hangup
- [ ] Verify call records have correct status=ended, end_at, disconnection_reason
- [ ] Verify no regression in warm transfer flow
- [ ] Monitor for STUCK_ONGOING calls after deployment

Generated with [Claude Code](https://claude.com/claude-code)