### PR TITLE
fix: add timeout defense for AgentSession.aclose() hang (PROD-1409)

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -17,6 +17,7 @@ if current_process().name == "job_proc":
 import asyncio
 import contextlib
 import socket
+import time
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import Any, Callable, cast
@@ -323,10 +324,39 @@ class _JobProc:
 
         shutdown_info = await self._shutdown_fut
 
-        # TODO(theomonnom): move this code?
-        if session := self._job_ctx._primary_agent_session:
-            await session.aclose()
+        _ACLOSE_TIMEOUT_SECONDS = 15.0
 
+        _room_name = self._room.name if self._room else None
+        if session := self._job_ctx._primary_agent_session:
+            _aclose_start = time.monotonic()
+            logger.info(
+                "shutdown: session.aclose() starting",
+                extra={"room": _room_name},
+            )
+            try:
+                await asyncio.wait_for(session.aclose(), timeout=_ACLOSE_TIMEOUT_SECONDS)
+                _aclose_elapsed_ms = round((time.monotonic() - _aclose_start) * 1000, 1)
+                logger.info(
+                    "shutdown: session.aclose() completed",
+                    extra={"elapsed_ms": _aclose_elapsed_ms, "room": _room_name},
+                )
+            except asyncio.TimeoutError:
+                _aclose_elapsed_ms = round((time.monotonic() - _aclose_start) * 1000, 1)
+                logger.error(
+                    "shutdown: session.aclose() timed out -- proceeding with shutdown chain",
+                    extra={
+                        "timeout_seconds": _ACLOSE_TIMEOUT_SECONDS,
+                        "elapsed_ms": _aclose_elapsed_ms,
+                        "room": _room_name,
+                    },
+                )
+            except Exception:
+                logger.exception(
+                    "shutdown: session.aclose() raised -- proceeding with shutdown chain",
+                    extra={"room": _room_name},
+                )
+
+        logger.info("shutdown: session_end phase starting")
         await self._job_ctx._on_session_end()
 
         if self._session_end_fnc:
@@ -340,8 +370,11 @@ class _JobProc:
             extra={"reason": shutdown_info.reason, "user_initiated": shutdown_info.user_initiated},
         )
         await self._client.send(Exiting(reason=shutdown_info.reason))
+
+        logger.info("shutdown: room.disconnect() starting")
         await self._room.disconnect()
 
+        logger.info("shutdown: shutdown_callbacks starting")
         try:
             shutdown_tasks = []
             for callback in self._job_ctx._shutdown_callbacks:
@@ -354,6 +387,7 @@ class _JobProc:
             await asyncio.gather(*shutdown_tasks)
         except Exception:
             logger.exception("error while shutting down the job")
+        logger.info("shutdown: shutdown_callbacks completed")
 
         self._job_ctx._on_cleanup()
         await http_context._close_http_ctx()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -701,14 +701,67 @@ class AgentActivity(RecognitionHooks):
         if isinstance(self.vad, vad.VAD):
             self.vad.off("metrics_collected", self._on_metrics_collected)
 
+        _RT_SESSION_CLOSE_TIMEOUT = 8.0
+        _AUDIO_RECOGNITION_CLOSE_TIMEOUT = 5.0
+
         if self._rt_session is not None:
-            await self._rt_session.aclose()
+            _start = time.monotonic()
+            logger.debug("closing rt_session")
+            try:
+                await asyncio.wait_for(
+                    self._rt_session.aclose(), timeout=_RT_SESSION_CLOSE_TIMEOUT
+                )
+                _elapsed_ms = round((time.monotonic() - _start) * 1000, 1)
+                if _elapsed_ms > 5000:
+                    logger.warning(
+                        "rt_session.aclose() slow", extra={"elapsed_ms": _elapsed_ms}
+                    )
+                else:
+                    logger.debug(
+                        "rt_session.aclose() completed", extra={"elapsed_ms": _elapsed_ms}
+                    )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "rt_session.aclose() timed out",
+                    extra={
+                        "timeout_seconds": _RT_SESSION_CLOSE_TIMEOUT,
+                        "elapsed_ms": round((time.monotonic() - _start) * 1000, 1),
+                    },
+                )
+            except Exception:
+                logger.exception("rt_session.aclose() raised")
 
         if self._realtime_spans is not None:
             self._realtime_spans.clear()
 
         if self._audio_recognition is not None:
-            await self._audio_recognition.aclose()
+            _start = time.monotonic()
+            logger.debug("closing audio_recognition")
+            try:
+                await asyncio.wait_for(
+                    self._audio_recognition.aclose(), timeout=_AUDIO_RECOGNITION_CLOSE_TIMEOUT
+                )
+                _elapsed_ms = round((time.monotonic() - _start) * 1000, 1)
+                if _elapsed_ms > 3000:
+                    logger.warning(
+                        "audio_recognition.aclose() slow",
+                        extra={"elapsed_ms": _elapsed_ms},
+                    )
+                else:
+                    logger.debug(
+                        "audio_recognition.aclose() completed",
+                        extra={"elapsed_ms": _elapsed_ms},
+                    )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "audio_recognition.aclose() timed out",
+                    extra={
+                        "timeout_seconds": _AUDIO_RECOGNITION_CLOSE_TIMEOUT,
+                        "elapsed_ms": round((time.monotonic() - _start) * 1000, 1),
+                    },
+                )
+            except Exception:
+                logger.exception("audio_recognition.aclose() raised")
 
         await self._interrupt_paused_speech(old_task=self._interrupt_paused_speech_task)
         self._interrupt_paused_speech_task = None


### PR DESCRIPTION
## Summary

- `session.aclose()`에 15초 outer timeout 추가 (`job_proc_lazy_main.py`)
- `rt_session.aclose()`에 8초, `audio_recognition.aclose()`에 5초 inner timeout 추가 (`agent_activity.py`)
- timeout/exception 발생 시에도 shutdown chain(session_end, room.disconnect, callbacks) 계속 진행
- 각 shutdown 단계에 structured logging (elapsed_ms, room_name)

## Context

2026-04-14 postmortem: `AgentSession.aclose()`가 `activity.aclose` 스텝에서 hang되면 전체 shutdown chain이 블로킹되어 `handle_shutdown` → `end_call` DB write가 실행되지 않음. 결과: stuck ongoing call + PID recycle로 인한 고객 재다이얼.

## Test plan

- [ ] staging 인바운드 콜 1건: 정상 종료 후 shutdown 로그가 순서대로 출력되는지 확인
- [ ] staging 아웃바운드 콜 1건: 정상 종료 후 calls 테이블에 status=ended 확인
- [ ] hang 시뮬레이션: `_aclose_impl`에 임시 `await asyncio.sleep(30)` 삽입 후 콜 종료, 15초 timeout 로그 확인 + shutdown chain 완주 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)