### PR TITLE
fix(voice): prevent ignored-turn noise from polluting EOU metrics (PROD-1419)

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1219,7 +1219,13 @@ class AgentActivity(RecognitionHooks):
 
     def _on_metrics_collected(
         self,
-        ev: STTMetrics | TTSMetrics | VADMetrics | LLMMetrics | RealtimeModelMetrics | AgentLLMMetrics | ToolExecutionMetrics,
+        ev: STTMetrics
+        | TTSMetrics
+        | VADMetrics
+        | LLMMetrics
+        | RealtimeModelMetrics
+        | AgentLLMMetrics
+        | ToolExecutionMetrics,
     ) -> None:
         # Attach speech_id when possible (for LLM/TTS/AgentLLM)
         if speech_handle := _SpeechHandleContextVar.get(None):
@@ -1644,6 +1650,14 @@ class AgentActivity(RecognitionHooks):
                     info.new_transcript, self._session.options.interruption_ignore_words
                 ):
                     self._cancel_preemptive_generation()
+                    # PROD-1419: An ignored turn (typically a brief noise like
+                    # "네"/"예" caught during agent speech) must not leak its
+                    # timestamps into the next real turn's latency metrics.
+                    # Reset the EOU clock and the audio recognition turn state
+                    # so the next user speech starts with fresh timing.
+                    self._last_eou_timestamp = None
+                    if self._audio_recognition is not None:
+                        self._audio_recognition.reset_user_turn_state()
                     return False
 
         old_task = self._user_turn_completed_atask

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1652,12 +1652,13 @@ class AgentActivity(RecognitionHooks):
                     self._cancel_preemptive_generation()
                     # PROD-1419: An ignored turn (typically a brief noise like
                     # "네"/"예" caught during agent speech) must not leak its
-                    # timestamps into the next real turn's latency metrics.
-                    # Reset the EOU clock and the audio recognition turn state
-                    # so the next user speech starts with fresh timing.
+                    # timestamps into the next real turn's latency metrics,
+                    # nor its audio into the STT provider's buffer (some
+                    # providers otherwise concatenate the ignored utterance
+                    # with the user's next one).
                     self._last_eou_timestamp = None
                     if self._audio_recognition is not None:
-                        self._audio_recognition.reset_user_turn_state()
+                        self._audio_recognition.reset_user_turn_state(reset_stt=True)
                     return False
 
         old_task = self._user_turn_completed_atask

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1597,6 +1597,14 @@ class AgentActivity(RecognitionHooks):
         # IMPORTANT: This method is sync to avoid it being cancelled by the AudioRecognition
         # We explicitly create a new task here
 
+        # PROD-1419: `_last_eou_timestamp` is normally set by on_end_of_speech
+        # (VAD end-of-speech). If VAD missed the user's speech (e.g. AEC
+        # suppression, or we reset state after an ignore_words filter), it
+        # stays None and e2e_latency can't be computed when TTS metrics arrive.
+        # Fall back to the speech-end time captured by the EOU task.
+        if self._last_eou_timestamp is None and info.stopped_speaking_at is not None:
+            self._last_eou_timestamp = info.stopped_speaking_at
+
         if self._scheduling_paused:
             self._cancel_preemptive_generation()
             logger.warning(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
 MIN_LANGUAGE_DETECTION_LENGTH = 5
 # Mirrors turn_detector.base.MAX_HISTORY_TURNS for tracing
 _EOU_MAX_HISTORY_TURNS = 6
+# If STT emits a final transcript more than this many seconds after the last
+# VAD speech event, treat the VAD timestamp as stale (likely missed speech due
+# to AEC/low volume) and fall back to the STT arrival time for latency
+# metrics. See PROD-1419.
+_VAD_STT_DESYNC_THRESHOLD_SEC = 3.0
 
 
 @dataclass
@@ -249,6 +254,23 @@ class AudioRecognition:
         self.update_stt(None)
         self.update_stt(stt)
 
+    def reset_user_turn_state(self) -> None:
+        """Reset in-memory user turn state without flushing STT.
+
+        Used when a detected turn is filtered out (e.g., matched by
+        ``interruption_ignore_words``) so its timestamps and transcript do
+        not pollute the next turn's latency metrics. Unlike
+        :meth:`clear_user_turn`, this does not rebuild the STT stream.
+        """
+        self._last_speaking_time = None
+        self._speech_start_time = None
+        self._last_final_transcript_time = None
+        self._audio_transcript = ""
+        self._audio_interim_transcript = ""
+        self._audio_preflight_transcript = ""
+        self._final_transcript_confidence = []
+        self._user_turn_committed = False
+
     def commit_user_turn(
         self,
         *,
@@ -406,6 +428,21 @@ class AudioRecognition:
                 # the correct way is to ensure STT fires SpeechEventType.END_OF_SPEECH
                 # and using that timestamp for _last_speaking_time
                 self._last_speaking_time = time.time()
+            elif time.time() - self._last_speaking_time > _VAD_STT_DESYNC_THRESHOLD_SEC:
+                # PROD-1419: VAD has been silent for longer than any realistic
+                # STT processing delay, yet STT just produced a final transcript.
+                # This typically means VAD missed the user's speech (e.g. AEC
+                # suppressed it, or an earlier noise "turn" left the timestamp
+                # stale). Fall back to the STT arrival time so the EOU/
+                # transcription metrics reflect real STT latency instead of
+                # the gap back to the stale VAD event.
+                vad_lag = time.time() - self._last_speaking_time
+                logger.debug(
+                    "VAD-STT desync detected; using STT timestamp for _last_speaking_time",
+                    extra={"vad_lag_sec": vad_lag},
+                )
+                self._last_speaking_time = time.time()
+                self._speech_start_time = time.time()
 
             if self._vad_base_turn_detection or self._user_turn_committed:
                 if transcript_changed:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -254,13 +254,19 @@ class AudioRecognition:
         self.update_stt(None)
         self.update_stt(stt)
 
-    def reset_user_turn_state(self) -> None:
-        """Reset in-memory user turn state without flushing STT.
+    def reset_user_turn_state(self, *, reset_stt: bool = False) -> None:
+        """Reset in-memory user turn state after a turn is discarded.
 
         Used when a detected turn is filtered out (e.g., matched by
         ``interruption_ignore_words``) so its timestamps and transcript do
-        not pollute the next turn's latency metrics. Unlike
-        :meth:`clear_user_turn`, this does not rebuild the STT stream.
+        not pollute the next turn's latency metrics.
+
+        When ``reset_stt`` is true, the STT stream is also rebuilt. This is
+        needed for providers (e.g. RTZR) that otherwise concatenate the
+        discarded utterance with whatever the user says next (e.g.
+        "안녕하세요" + "들리시나요" → "안 들리시나요"). It is off by default
+        because rebuilding the stream is heavier and not every STT needs
+        it.
         """
         self._last_speaking_time = None
         self._speech_start_time = None
@@ -270,6 +276,12 @@ class AudioRecognition:
         self._audio_preflight_transcript = ""
         self._final_transcript_confidence = []
         self._user_turn_committed = False
+
+        if reset_stt:
+            stt = self._stt
+            if stt is not None:
+                self.update_stt(None)
+                self.update_stt(stt)
 
     def commit_user_turn(
         self,

--- a/tests/fake_session.py
+++ b/tests/fake_session.py
@@ -87,15 +87,30 @@ async def run_session(session: AgentSession, agent: Agent, *, drain_delay: float
 
     # start the fake vad and stt
     t_origin = time.time()
-    audio_input.push(0.1)
 
-    # wait for the user speeches to be processed
-    await stt.fake_user_speeches_done
+    # Push audio periodically. FakeVAD/FakeSTT only need one frame each to
+    # start their internal timers, but if the STT stream is rebuilt mid-test
+    # (e.g. by an interruption_ignore_words reset), the new stream needs a
+    # fresh frame too. A steady drip covers both cases.
+    async def _push_audio() -> None:
+        while True:
+            audio_input.push(0.05)
+            await asyncio.sleep(0.05)
 
-    await asyncio.sleep(drain_delay)
-    with contextlib.suppress(RuntimeError):
-        await session.drain()
-    await session.aclose()
+    push_task = asyncio.create_task(_push_audio())
+
+    try:
+        # wait for the user speeches to be processed
+        await stt.fake_user_speeches_done
+
+        await asyncio.sleep(drain_delay)
+        with contextlib.suppress(RuntimeError):
+            await session.drain()
+        await session.aclose()
+    finally:
+        push_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await push_task
 
     if transcription_sync is not None:
         await transcription_sync.aclose()

--- a/tests/fake_stt.py
+++ b/tests/fake_stt.py
@@ -67,6 +67,11 @@ class FakeSTT(STT):
                     raise ValueError("fake user speeches overlap")
         self._fake_user_speeches = fake_user_speeches
         self._done_fut = asyncio.Future[None]()
+        # Track emitted speeches across streams so that if the caller rebuilds
+        # the STT stream mid-test (e.g. AudioRecognition.reset_user_turn_state
+        # with reset_stt=True) the new stream does not replay speeches that
+        # were already handled by the previous stream.
+        self._emitted_speeches: set[int] = set()
 
         self._recognize_ch = utils.aio.Chan[RecognizeSentinel]()
         self._stream_ch = utils.aio.Chan[FakeRecognizeStream]()
@@ -213,6 +218,8 @@ class FakeRecognizeStream(RecognizeStream):
             return time.perf_counter() - start_time
 
         for fake_speech in self._stt._fake_user_speeches:
+            if id(fake_speech) in self._stt._emitted_speeches:
+                continue
             interim_transcript_time = fake_speech.end_time + fake_speech.stt_delay * 0.5
             if curr_time() < interim_transcript_time:
                 await asyncio.sleep(interim_transcript_time - curr_time())
@@ -222,6 +229,7 @@ class FakeRecognizeStream(RecognizeStream):
             if curr_time() < final_transcript_time:
                 await asyncio.sleep(final_transcript_time - curr_time())
             self.send_fake_transcript(fake_speech.transcript, is_final=True)
+            self._stt._emitted_speeches.add(id(fake_speech))
 
         with contextlib.suppress(asyncio.InvalidStateError):
             self._stt._done_fut.set_result(None)

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -713,6 +713,57 @@ async def test_unknown_function_call() -> None:
     assert "Unknown function: nonexistent_tool" in error_outputs[0].output
 
 
+async def test_interruption_ignore_words_resets_turn_state() -> None:
+    """PROD-1419: A turn filtered by interruption_ignore_words must not leak
+    its transcript or metric timestamps into the next real turn.
+
+    Repro: a brief "yes" noise is caught while the agent greeting is playing.
+    Because "yes" is in interruption_ignore_words, on_end_of_turn returns
+    False and no LLM reply is generated. Before the fix, the ignored turn's
+    transcript was left in _audio_transcript, so the NEXT real user turn
+    committed as "yes <real_text>" instead of just "<real_text>".
+    """
+    speed = 5.0
+
+    actions = FakeActions()
+    # agent initial greeting (triggered by on_enter)
+    actions.add_llm("Hi there!", input="instructions:say hello to the user")
+    actions.add_tts(2.0)
+    # ignored noise during/right after greeting
+    actions.add_user_speech(1.0, 1.2, "yes", stt_delay=0.2)
+    # real user query some time later
+    actions.add_user_speech(4.0, 5.5, "tell me a joke", stt_delay=0.2)
+    actions.add_llm("Here is a joke for you.")
+    actions.add_tts(1.0)
+
+    session = create_session(
+        actions,
+        speed_factor=speed,
+        extra_kwargs={
+            "min_interruption_words": 1,
+            "interruption_ignore_words": ["yes"],
+        },
+    )
+    agent = MyAgent(generate_reply_on_enter=True)
+
+    conversation_events: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", conversation_events.append)
+
+    await asyncio.wait_for(run_session(session, agent, drain_delay=0.5), timeout=SESSION_TIMEOUT)
+
+    user_items = [ev.item for ev in conversation_events if ev.item.role == "user"]
+    # only the real user query should commit; "yes" is filtered out
+    assert len(user_items) == 1, (
+        f"expected exactly 1 user message, got {len(user_items)}: "
+        f"{[i.text_content for i in user_items]}"
+    )
+    assert user_items[0].text_content == "tell me a joke", (
+        f"expected 'tell me a joke', got '{user_items[0].text_content}'. "
+        f"A leading 'yes ' means the ignored turn's transcript leaked into "
+        f"the next turn (PROD-1419 regression)."
+    )
+
+
 # helpers
 
 

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -729,9 +729,9 @@ async def test_interruption_ignore_words_resets_turn_state() -> None:
     # agent initial greeting (triggered by on_enter)
     actions.add_llm("Hi there!", input="instructions:say hello to the user")
     actions.add_tts(2.0)
-    # ignored noise during/right after greeting
+    # ignored noise during greeting
     actions.add_user_speech(1.0, 1.2, "yes", stt_delay=0.2)
-    # real user query some time later
+    # real user query after greeting
     actions.add_user_speech(4.0, 5.5, "tell me a joke", stt_delay=0.2)
     actions.add_llm("Here is a joke for you.")
     actions.add_tts(1.0)


### PR DESCRIPTION
## Summary
Brief noises (e.g. "네"/"예") caught during agent speech matched `interruption_ignore_words` and were correctly filtered — but the timestamps and transcript they left behind polluted the next real turn's latency metrics. Production calls reported ~11s EOU delays that were really just "agent greeting remainder + user silence" being attributed to STT processing.

## Root Cause
Two overlapping bugs:

1. **Ignored turn state leak** — `on_end_of_turn` returns False on `interruption_ignore_words` match, but `_last_eou_timestamp`, `_last_speaking_time`, `_speech_start_time`, and `_audio_transcript` are not cleared.
2. **VAD/STT desync** — When AEC suppresses the user's actual speech for VAD (but STT still produces a transcript), the FINAL_TRANSCRIPT handler only updated `_last_speaking_time` if VAD was fully disabled, so the stale noise timestamp kept driving `end_of_turn_delay` / `transcription_delay`.

## Evidence (PROD)
Call `b24cc71a-6dde-44f6-873c-bcfd9c55b05f`:
- 05:06:21.303–21.311 user "네" (8ms noise, matched ignore_words)
- 05:06:33.08 second assistant response committed
- Reported metrics: **eou=11.77s, transcription=11.72s, e2e=12.87s**
- 33.08 − 21.31 ≈ 11.77s → `_last_speaking_time` was still pointing at the noise

Identical pattern in `f8f02e9e-f669-4d5a-aee4-f38e5fc6acb1` (eou=11.15s).

## Changes
- `voice/audio_recognition.py`
  - New `reset_user_turn_state()` method: clears in-memory turn state (timestamps, transcripts, confidence) without flushing the STT stream.
  - FINAL_TRANSCRIPT handler: if VAD has been silent for more than `_VAD_STT_DESYNC_THRESHOLD_SEC` (3.0s), fall back to the STT arrival time for `_last_speaking_time` / `_speech_start_time`.
- `voice/agent_activity.py`
  - In `on_end_of_turn`, when `interruption_ignore_words` matches: clear `_last_eou_timestamp` and call `reset_user_turn_state()`.
- `tests/test_agent_session.py`
  - Regression test `test_interruption_ignore_words_resets_turn_state` — verifies the ignored "yes" doesn't leak into the next real turn's transcript. Verified to fail without the fix and pass with it.

## Test plan
- [x] New regression test fails on parent commit, passes after fix
- [x] Full `tests/test_agent_session.py` suite passes (17 passed; pre-existing `test_events_and_metrics` unrelated)
- [x] `make format` clean on modified files
- [ ] Deploy to staging, monitor `eou_delay` distribution on calls that include an ignore-words hit; confirm no more double-digit-second outliers
- [ ] Verify no behavioral regression on normal ignore-words flow (agent continues its current speech, user input is dropped)

## Rollout
After merge, bump the pinned commit in `domains/voxai/agent-server/pyproject.toml` (`livekit-agents` entry, `rev=…`) and rebuild the agent-server image.