### PR TITLE
fix(voice): clear EOU metric timestamps on rejected user turn

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -622,6 +622,17 @@ class AudioRecognition:
                 self._last_speaking_time = None
                 self._last_final_transcript_time = None
                 self._speech_start_time = None
+            else:
+                # Rejected turn (e.g. transcript below min_interruption_words,
+                # typical for short noise/filler during agent speech).
+                # Reset the metric reference timestamps so the next real turn's
+                # transcription_delay / end_of_turn_delay / started_speaking_at
+                # are not anchored to this rejected event. Transcript is kept
+                # so a follow-up utterance can still accumulate into the same
+                # logical user turn.
+                self._last_speaking_time = None
+                self._last_final_transcript_time = None
+                self._speech_start_time = None
 
             self._user_turn_committed = False
 


### PR DESCRIPTION
## Summary

Fix metric pollution in `AudioRecognition` when a user turn is rejected by `on_end_of_turn`.

## Background

`_bounce_eou_task` computes per-turn metrics from three reference timestamps:

- `_last_speaking_time` — last VAD-detected user speech (EOU clock)
- `_last_final_transcript_time` — FINAL_TRANSCRIPT arrival time
- `_speech_start_time` — user speech start time

These values are reset to `None` when `on_end_of_turn` returns `True`, but not when it returns `False`.

## Problem

When a user-speech event is picked up by VAD/STT but rejected at turn commit (for example, a very short transcript that fails a host-side interruption-word threshold check and causes `on_end_of_turn` to return `False`), the three metric reference timestamps stay anchored to that rejected event.

The next legitimate user turn then reports `transcription_delay`, `end_of_turn_delay`, and `started_speaking_at` relative to the stale timestamp, inflating the reported latencies by any time elapsed between the rejected event and the next real turn.

## Fix

Add an `else` branch symmetric with the `committed` branch that resets only the three metric reference timestamps. Transcript accumulation (`_audio_transcript`, `_final_transcript_confidence`) and `_user_turn_span` are preserved so a short filler followed by a real utterance still composes into one logical user turn.

```python
else:
    # Rejected turn (e.g. transcript below a host-side interruption
    # threshold, typical for short noise/filler during agent speech).
    # Reset the metric reference timestamps so the next real turn's
    # transcription_delay / end_of_turn_delay / started_speaking_at
    # are not anchored to this rejected event. Transcript is kept
    # so a follow-up utterance can still accumulate into the same
    # logical user turn.
    self._last_speaking_time = None
    self._last_final_transcript_time = None
    self._speech_start_time = None
```

## Notes

- The `transcription_delay` and `end_of_turn_delay` formulas themselves are unchanged — only the reference-timestamp lifecycle is corrected.
- Intentionally preserved across rejection: `_audio_transcript`, `_final_transcript_confidence`, `_user_turn_span`, `_user_turn_committed`.

## Test plan

- [ ] Short noise during agent TTS playout: verify `transcription_delay` / `end_of_turn_delay` on the next real user turn reflect only the real turn's timings.
- [ ] Normal turn (silence → speech → commit): no regression in end-to-end metrics.
- [ ] Filler + follow-up utterance: still accumulates into one committed turn.