### PR TITLE
fix(voice): freeze final-transcript clock during VAD silence

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -364,7 +364,8 @@ class AudioRecognition:
                 extra["transcript_delay"] = time.time() - self._last_speaking_time
             logger.debug("received user transcript", extra=extra)
 
-            self._last_final_transcript_time = time.time()
+            if self._should_advance_final_transcript_clock():
+                self._last_final_transcript_time = time.time()
             self._audio_transcript += f" {transcript}"
             self._audio_transcript = self._audio_transcript.lstrip()
             self._final_transcript_confidence.append(confidence)
@@ -420,7 +421,8 @@ class AudioRecognition:
             )
 
             # still need to increment it as it's used for turn detection,
-            self._last_final_transcript_time = time.time()
+            if self._should_advance_final_transcript_clock():
+                self._last_final_transcript_time = time.time()
             # preflight transcript includes all pre-committed transcripts (including final transcript from the previous STT run)
             self._audio_preflight_transcript = (self._audio_transcript + " " + transcript).lstrip()
             self._audio_interim_transcript = transcript
@@ -698,3 +700,24 @@ class AudioRecognition:
             _set_participant_attributes(self._user_turn_span, room_io.linked_participant)
 
         return self._user_turn_span
+
+    def _should_advance_final_transcript_clock(self) -> bool:
+        # STT can emit final/preflight transcripts long after the user has
+        # actually stopped speaking (agent-TTS echo, late buffer flushes from
+        # providers that don't emit END_OF_SPEECH, ghost events during silence).
+        # If we blindly advance _last_final_transcript_time on every such event,
+        # transcription_delay (= last_final - last_speaking) grows without bound
+        # while _last_speaking_time stays pinned to the true VAD end, producing
+        # inflated metrics attributed to the wrong turn.
+        #
+        # Only advance the clock when the event plausibly belongs to the
+        # current user turn:
+        #   - no prior speech tracked yet (first event of the turn), or
+        #   - VAD currently reports speech, or
+        #   - the event arrived within the max endpointing window (legit
+        #     late STT arrival for a turn that's still being endpointed).
+        if self._last_speaking_time is None:
+            return True
+        if self._speaking:
+            return True
+        return time.time() - self._last_speaking_time <= self._max_endpointing_delay


### PR DESCRIPTION
## Summary

Prevent `_last_final_transcript_time` from drifting forward on STT events that arrive long after the user has stopped speaking. These late events would otherwise inflate `transcription_delay` and `end_of_turn_delay` for the subsequent committed turn.

## Background

`_bounce_eou_task` computes per-turn metrics from two timestamps:

- `_last_speaking_time` — updated by VAD when speech is detected
- `_last_final_transcript_time` — updated by STT on `FINAL_TRANSCRIPT` and `PREFLIGHT_TRANSCRIPT`

The metric is

```
transcription_delay = last_final_transcript_time − last_speaking_time
end_of_turn_delay   = commit_time − last_speaking_time
```

Both are meant to measure latencies inside a single user turn.

## Problem

STT providers sometimes emit `FINAL_TRANSCRIPT` / `PREFLIGHT_TRANSCRIPT` events long after the user has actually stopped speaking:

- agent-TTS echoing back into the user audio input
- late buffer flush from providers that don't emit `END_OF_SPEECH`
- "ghost" finals during silence where the provider re-emits a prior transcript

Because `_last_final_transcript_time` is advanced on every such event while `_last_speaking_time` stays pinned to the true VAD end, the gap grows without bound during silence. `_bounce_eou_task` is rescheduled on every new STT event and captures the drifted live values at the time of rescheduling. The eventually-committed turn then carries an inflated `transcription_delay` / `end_of_turn_delay`.

Observed in practice: a short filler ("네") during an agent greeting produces `transcription_delay = 11.72s` and `end_of_turn_delay = 11.77s` on the committed user turn, even though the user's actual utterance was ~8ms.

## Fix

Gate the clock advance on the STT paths so only events that plausibly belong to the current user turn move `_last_final_transcript_time` forward:

```python
def _should_advance_final_transcript_clock(self) -> bool:
    if self._last_speaking_time is None:
        return True
    if self._speaking:
        return True
    return time.time() - self._last_speaking_time <= self._max_endpointing_delay
```

Applied at both `FINAL_TRANSCRIPT` and `PREFLIGHT_TRANSCRIPT` handlers. Events outside those windows are treated as ghost/echo and do not re-anchor the clock. The metric formulas themselves are unchanged.

## Why this bound

The `max_endpointing_delay` window is already the upper bound on how long a turn can stay in endpointing before commit. An STT event arriving after that window is by definition not going to drive this turn's commit, so it should not move the metric reference either.

## Notes

- No API/contract change.
- `_audio_transcript` accumulation is unchanged; the transcript content still flows normally into the committed turn.
- The intent is conservative: if the user is actively speaking (`self._speaking`) or the event lands inside the endpointing window, the clock advances as before. Only ghost events during extended silence are filtered.

## Test plan

- [ ] Short filler during long agent speech followed by silence: the next committed turn reports `transcription_delay` near actual STT latency (not the full silence gap).
- [ ] Normal turn (silence → speech → commit): no change in end-to-end metrics.
- [ ] Late STT final that lands within `max_endpointing_delay` after VAD END: still counted, turn metrics unchanged vs. current behavior.
- [ ] User turn that spans multiple short utterances (filler + follow-up): transcript accumulation works, metrics reflect the final real utterance.