### PR TITLE
fix(voice): freeze final-transcript clock during VAD silence

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -390,7 +390,8 @@ class AudioRecognition:
                 extra["transcript_delay"] = time.time() - self._last_speaking_time
             logger.debug("received user transcript", extra=extra)
 
-            self._last_final_transcript_time = time.time()
+            if self._should_advance_final_transcript_clock():
+                self._last_final_transcript_time = time.time()
             self._audio_transcript += f" {transcript}"
             self._audio_transcript = self._audio_transcript.lstrip()
             self._final_transcript_confidence.append(confidence)
@@ -451,7 +452,8 @@ class AudioRecognition:
             )
 
             # still need to increment it as it's used for turn detection,
-            self._last_final_transcript_time = time.time()
+            if self._should_advance_final_transcript_clock():
+                self._last_final_transcript_time = time.time()
             # preflight transcript includes all pre-committed transcripts (including final transcript from the previous STT run)
             self._audio_preflight_transcript = (self._audio_transcript + " " + transcript).lstrip()
             self._audio_interim_transcript = transcript
@@ -766,3 +768,24 @@ class AudioRecognition:
             _set_participant_attributes(self._user_turn_span, room_io.linked_participant)
 
         return self._user_turn_span
+
+    def _should_advance_final_transcript_clock(self) -> bool:
+        # STT can emit final/preflight transcripts long after the user has
+        # actually stopped speaking (agent-TTS echo, late buffer flushes from
+        # providers that don't emit END_OF_SPEECH, ghost events during silence).
+        # If we blindly advance _last_final_transcript_time on every such event,
+        # transcription_delay (= last_final - last_speaking) grows without bound
+        # while _last_speaking_time stays pinned to the true VAD end, producing
+        # inflated metrics attributed to the wrong turn.
+        #
+        # Only advance the clock when the event plausibly belongs to the
+        # current user turn:
+        #   - no prior speech tracked yet (first event of the turn), or
+        #   - VAD currently reports speech, or
+        #   - the event arrived within the max endpointing window (legit
+        #     late STT arrival for a turn that's still being endpointed).
+        if self._last_speaking_time is None:
+            return True
+        if self._speaking:
+            return True
+        return time.time() - self._last_speaking_time <= self._max_endpointing_delay


### PR DESCRIPTION
## Summary

Gate `_last_final_transcript_time` updates so STT events arriving during extended VAD silence do not re-anchor EOU-clock-dependent metrics.

Cherry-picked on top of `temp-1.4.6` (the production fork lineage). Superseded PR #13 which targeted `main` by mistake.

## Problem

`_bounce_eou_task` computes `transcription_delay = last_final_transcript_time − last_speaking_time`. `_last_speaking_time` is only updated by VAD; `_last_final_transcript_time` is updated on every `FINAL_TRANSCRIPT` / `PREFLIGHT_TRANSCRIPT`.

STT providers can keep emitting final/preflight events long after VAD saw silence:

- agent-TTS echoing back into the user audio input (common on SIP where acoustic echo cancellation is not perfect)
- late buffer flushes from providers that don't emit `END_OF_SPEECH`
- ghost events where the provider re-emits a prior transcript

Every such event advances `_last_final_transcript_time`. Because `_bounce_eou_task` is re-scheduled on each new STT event with the current live state captured as closure, drift accumulates. The task that eventually commits the turn reports a transcription_delay / end_of_turn_delay inflated by the entire silence duration.

Observed in practice: a short filler (~8ms "네") during an agent greeting produces `transcription_delay = 11.72s` and `end_of_turn_delay = 11.77s` on the committed user turn. Confirmed via trace spans showing `_last_speaking_time` frozen at 21.31 while `_last_final_transcript_time` advanced to 33.03.

## Fix

```python
def _should_advance_final_transcript_clock(self) -> bool:
    if self._last_speaking_time is None:
        return True
    if self._speaking:
        return True
    return time.time() - self._last_speaking_time <= self._max_endpointing_delay
```

Gate both `FINAL_TRANSCRIPT` and `PREFLIGHT_TRANSCRIPT` handlers with this helper. Events outside the endpointing window are treated as ghost/echo and do not re-anchor the clock. The metric formulas themselves are unchanged.

## Why this bound

`max_endpointing_delay` is already the upper bound on how long a turn can stay in endpointing before commit. An STT event arriving after that window is by definition not going to drive this turn's commit, so it should not move the metric reference either.

## Notes

- No API/contract change.
- `_audio_transcript` accumulation is unchanged.
- During active speech (`self._speaking`) or inside the endpointing window the clock advances as before. Only events during extended silence are filtered.

## Test plan

- [ ] Short filler during long agent speech followed by silence: committed-turn `transcription_delay` reflects actual STT latency, not the silence gap.
- [ ] Normal turn (silence → speech → commit): no change in metrics.
- [ ] Late STT final inside `max_endpointing_delay` after VAD END: still counted.
- [ ] Filler + follow-up utterance: transcript accumulation works, metrics reflect the real utterance.