### PR TITLE
Fix AudioRecognition close on cancelled EOU task

### DIFF
--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -58,7 +58,7 @@ MCPToolResultResolver = Callable[[MCPToolResultContext], Any | Awaitable[Any]]
 def _default_tool_result_resolver(ctx: MCPToolResultContext) -> str:
     # TODO(theomonnom): handle images & binary messages
     if len(ctx.result.content) == 1:
-        return ctx.result.content[0].model_dump_json()
+        return str(ctx.result.content[0].model_dump_json())
     elif len(ctx.result.content) > 1:
         return json.dumps([item.model_dump() for item in ctx.result.content])
 

--- a/livekit-agents/livekit/agents/metrics/__init__.py
+++ b/livekit-agents/livekit/agents/metrics/__init__.py
@@ -6,8 +6,8 @@ from .base import (
     RealtimeModelMetrics,
     ResponseLatencyMetrics,
     STTMetrics,
-    TTSMetrics,
     ToolExecutionMetrics,
+    TTSMetrics,
     VADMetrics,
 )
 from .usage_collector import UsageCollector, UsageSummary

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Metadata(BaseModel):
@@ -156,9 +156,6 @@ class AgentLLMMetrics(BaseModel):
     llm_node_await: float | None = None
     request_id: str | None = None
     metadata: Metadata | None = None
-
-
-from pydantic import Field
 
 
 class ToolExecutionMetrics(BaseModel):

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -132,9 +132,6 @@ class RealtimeModelMetrics(BaseModel):
     metadata: Metadata | None = None
 
 
-AgentMetrics = STTMetrics | LLMMetrics | TTSMetrics | VADMetrics | EOUMetrics | RealtimeModelMetrics
-
-
 # --- Extended metrics (adaptive endpointing & tooling visibility) ---
 
 
@@ -167,8 +164,7 @@ class ToolExecutionMetrics(BaseModel):
     metadata: Metadata | None = None
 
 
-# Extend AgentMetrics union with new metric types
-AgentMetrics = (  # type: ignore[misc]
+AgentMetrics = (
     STTMetrics
     | LLMMetrics
     | TTSMetrics

--- a/livekit-agents/livekit/agents/metrics/utils.py
+++ b/livekit-agents/livekit/agents/metrics/utils.py
@@ -11,8 +11,8 @@ from .base import (
     RealtimeModelMetrics,
     ResponseLatencyMetrics,
     STTMetrics,
-    TTSMetrics,
     ToolExecutionMetrics,
+    TTSMetrics,
 )
 
 

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
-from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Generator
+from collections.abc import AsyncGenerator, AsyncIterable, Callable, Coroutine, Generator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from livekit import rtc
 

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from livekit import rtc
 
 from .. import inference, llm, stt, tokenize, tts, utils, vad
-from ..llm import ChatContext, RealtimeModel, ToolError, find_function_tools
+from ..llm import ChatContext, ChatItem, RealtimeModel, ToolError, find_function_tools
 from ..llm.chat_context import Instructions, _ReadOnlyChatContext
 from ..log import logger
 from ..types import NOT_GIVEN, FlushSentinel, NotGivenOr
@@ -88,9 +88,9 @@ class Agent:
         self._mcp_servers = mcp_servers
         self._activity: AgentActivity | None = None
         # Reply callback tracking
-        self._reply_chat_ctx: llm.ChatContext | None = None
-        self._reply_messages: list[llm.ChatItem] = []
-        self._reply_callbacks: list[Callable[[llm.ChatContext, list[llm.ChatItem]], None]] = []
+        self._reply_chat_ctx: ChatContext | None = None
+        self._reply_messages: list[ChatItem] = []
+        self._reply_callbacks: list[Callable[[ChatContext, list[ChatItem]], None]] = []
 
     @property
     def id(self) -> str:
@@ -212,20 +212,20 @@ class Agent:
     # -- Reply callbacks --
     def add_reply_callback(
         self,
-        callback: Callable[[llm.ChatContext, list[llm.ChatItem]], None],
+        callback: Callable[[ChatContext, list[ChatItem]], None],
     ) -> None:
         self._reply_callbacks.append(callback)
 
     def remove_reply_callback(
         self,
-        callback: Callable[[llm.ChatContext, list[llm.ChatItem]], None],
+        callback: Callable[[ChatContext, list[ChatItem]], None],
     ) -> None:
         try:
             self._reply_callbacks.remove(callback)
         except ValueError:
             pass
 
-    def reply_callback(self, chat_ctx: llm.ChatContext, replies: list[llm.ChatItem]) -> None:
+    def reply_callback(self, chat_ctx: ChatContext, replies: list[ChatItem]) -> None:
         if not replies:
             return
         for cb in self._reply_callbacks:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -41,7 +41,6 @@ from ..tokenize.basic import split_words
 from ..types import NOT_GIVEN, FlushSentinel, NotGivenOr
 from ..utils.misc import is_given
 from ._utils import _set_participant_attributes
-from .dynamic_interruption import DynamicInterruptionManager
 from .agent import (
     Agent,
     ModelSettings,
@@ -55,6 +54,7 @@ from .audio_recognition import (
     _EndOfTurnInfo,
     _PreemptiveGenerationInfo,
 )
+from .dynamic_interruption import DynamicInterruptionManager
 from .events import (
     AgentFalseInterruptionEvent,
     AgentState,
@@ -877,9 +877,7 @@ class AgentActivity(RecognitionHooks):
                     "speech_tasks_count": len(self._speech_tasks),
                     "has_scheduling_task": self._scheduling_atask is not None,
                     "scheduling_task_done": (
-                        bool(self._scheduling_atask.done())
-                        if self._scheduling_atask
-                        else None
+                        bool(self._scheduling_atask.done()) if self._scheduling_atask else None
                     ),
                 },
             )
@@ -1271,7 +1269,13 @@ class AgentActivity(RecognitionHooks):
 
     def _on_metrics_collected(
         self,
-        ev: STTMetrics | TTSMetrics | VADMetrics | LLMMetrics | RealtimeModelMetrics | AgentLLMMetrics | ToolExecutionMetrics,
+        ev: STTMetrics
+        | TTSMetrics
+        | VADMetrics
+        | LLMMetrics
+        | RealtimeModelMetrics
+        | AgentLLMMetrics
+        | ToolExecutionMetrics,
     ) -> None:
         # Attach speech_id when possible (for LLM/TTS/AgentLLM)
         if speech_handle := _SpeechHandleContextVar.get(None):
@@ -1895,7 +1899,7 @@ class AgentActivity(RecognitionHooks):
     # endregion
 
     # Ensure agent state updates always trigger dynamic hooks
-    def _update_agent_state(self, state: "AgentState", **kwargs) -> None:
+    def _update_agent_state(self, state: AgentState, **kwargs) -> None:
         self._session._update_agent_state(state, **kwargs)
         if state == "speaking":
             self._dynamic_interruption.on_agent_speech_started()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1899,7 +1899,7 @@ class AgentActivity(RecognitionHooks):
     # endregion
 
     # Ensure agent state updates always trigger dynamic hooks
-    def _update_agent_state(self, state: AgentState, **kwargs) -> None:
+    def _update_agent_state(self, state: AgentState, **kwargs: Any) -> None:
         self._session._update_agent_state(state, **kwargs)
         if state == "speaking":
             self._dynamic_interruption.on_agent_speech_started()

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -900,13 +900,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     if not drain:
                         try:
                             # force interrupt speeches when closing the session
-                            _log_aclose_trace(
-                                "step_start", step="activity.interrupt(force=True)"
-                            )
+                            _log_aclose_trace("step_start", step="activity.interrupt(force=True)")
                             await activity.interrupt(force=True)
-                            _log_aclose_trace(
-                                "step_done", step="activity.interrupt(force=True)"
-                            )
+                            _log_aclose_trace("step_done", step="activity.interrupt(force=True)")
                         except RuntimeError:
                             # uninterruptible speech
                             _log_aclose_trace(
@@ -954,13 +950,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                     self._user_speaking_span = None
 
                 if self._forward_audio_atask is not None:
-                    _log_aclose_trace(
-                        "step_start", step="forward_audio.cancel_and_wait"
-                    )
+                    _log_aclose_trace("step_start", step="forward_audio.cancel_and_wait")
                     await utils.aio.cancel_and_wait(self._forward_audio_atask)
-                    _log_aclose_trace(
-                        "step_done", step="forward_audio.cancel_and_wait"
-                    )
+                    _log_aclose_trace("step_done", step="forward_audio.cancel_and_wait")
 
                 if self._recorder_io:
                     _log_aclose_trace("step_start", step="recorder_io.aclose")
@@ -989,13 +981,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
                 # close client events handler before room io
                 if self._client_events_handler:
-                    _log_aclose_trace(
-                        "step_start", step="client_events_handler.aclose"
-                    )
+                    _log_aclose_trace("step_start", step="client_events_handler.aclose")
                     await self._client_events_handler.aclose()
-                    _log_aclose_trace(
-                        "step_done", step="client_events_handler.aclose"
-                    )
+                    _log_aclose_trace("step_done", step="client_events_handler.aclose")
                     self._client_events_handler = None
 
                 # close room io after close event is emitted

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -215,7 +215,10 @@ class AudioRecognition:
 
         if self._commit_user_turn_atask is not None:
             logger.info("AudioRecognition.aclose commit_user_turn_task await start")
-            await self._commit_user_turn_atask
+            try:
+                await self._commit_user_turn_atask
+            except asyncio.CancelledError:
+                logger.info("AudioRecognition.aclose commit_user_turn_task cancelled")
             logger.info("AudioRecognition.aclose commit_user_turn_task await done")
 
         logger.info(
@@ -250,18 +253,10 @@ class AudioRecognition:
                     "end_of_turn_task_cancelled": end_of_turn_task.cancelled(),
                 },
             )
-            if end_of_turn_task.cancelled():
-                logger.info("AudioRecognition.aclose end_of_turn_task already cancelled")
-            else:
-                try:
-                    await asyncio.shield(end_of_turn_task)
-                except asyncio.CancelledError:
-                    if end_of_turn_task.cancelled():
-                        logger.info(
-                            "AudioRecognition.aclose end_of_turn_task cancelled during close"
-                        )
-                    else:
-                        raise
+            try:
+                await end_of_turn_task
+            except asyncio.CancelledError:
+                logger.info("AudioRecognition.aclose end_of_turn_task cancelled")
             logger.info("AudioRecognition.aclose end_of_turn_task await done")
 
         logger.info("AudioRecognition.aclose done")

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -242,11 +242,26 @@ class AudioRecognition:
             logger.info("AudioRecognition.aclose vad_task cancel done")
 
         if self._end_of_turn_task is not None:
+            end_of_turn_task = self._end_of_turn_task
             logger.info(
                 "AudioRecognition.aclose end_of_turn_task await start",
-                extra={"end_of_turn_task_done": self._end_of_turn_task.done()},
+                extra={
+                    "end_of_turn_task_done": end_of_turn_task.done(),
+                    "end_of_turn_task_cancelled": end_of_turn_task.cancelled(),
+                },
             )
-            await self._end_of_turn_task
+            if end_of_turn_task.cancelled():
+                logger.info("AudioRecognition.aclose end_of_turn_task already cancelled")
+            else:
+                try:
+                    await asyncio.shield(end_of_turn_task)
+                except asyncio.CancelledError:
+                    if end_of_turn_task.cancelled():
+                        logger.info(
+                            "AudioRecognition.aclose end_of_turn_task cancelled during close"
+                        )
+                    else:
+                        raise
             logger.info("AudioRecognition.aclose end_of_turn_task await done")
 
         logger.info("AudioRecognition.aclose done")

--- a/livekit-agents/livekit/agents/voice/dynamic_interruption.py
+++ b/livekit-agents/livekit/agents/voice/dynamic_interruption.py
@@ -7,7 +7,7 @@ from ..log import logger
 
 # Typed only for clarity; avoid importing to reduce risk of circular imports at import time
 try:  # pragma: no cover - type hint convenience
-    from .agent_session import AgentSessionOptions  # type: ignore
+    from .agent_session import AgentSessionOptions
 except Exception:  # pragma: no cover
     AgentSessionOptions = object  # type: ignore
 

--- a/livekit-agents/livekit/agents/voice/dynamic_interruption.py
+++ b/livekit-agents/livekit/agents/voice/dynamic_interruption.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+
 from ..log import logger
 
 # Typed only for clarity; avoid importing to reduce risk of circular imports at import time

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -63,7 +63,7 @@ def perform_llm_inference(
     chat_ctx: ChatContext,
     tool_ctx: ToolContext,
     model_settings: ModelSettings,
-    session: "AgentSession | None" = None,
+    session: AgentSession | None = None,
 ) -> tuple[asyncio.Task[bool], _LLMGenerationData]:
     text_ch = aio.Chan[str | FlushSentinel]()
     function_ch = aio.Chan[llm.FunctionCall]()
@@ -92,7 +92,7 @@ async def _llm_inference_task(
     model_settings: ModelSettings,
     data: _LLMGenerationData,
     *,
-    session: "AgentSession | None" = None,
+    session: AgentSession | None = None,
 ) -> bool:
     start_time = time.perf_counter()
     current_span = trace.get_current_span()
@@ -248,11 +248,7 @@ async def _llm_inference_task(
                     data.generated_text += chunk.delta.content
                     text_ch.send_nowait(chunk.delta.content)
 
-                    if (
-                        not ttft_captured
-                        and chunk.delta.content.strip()
-                        and session is not None
-                    ):
+                    if not ttft_captured and chunk.delta.content.strip() and session is not None:
                         ttft_captured = True
                         first_chunk_elapsed = time.time() - agent_llm_start_time
                         agent_ttft = first_chunk_elapsed

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -776,17 +776,25 @@ async def _execute_tools_task(
                     except Exception:
                         pass
 
-                task.add_done_callback(
-                    lambda t, _name=fnc_call.name, _started=started_at: _record_tool_duration(
-                        t, name=_name, started_at=_started
-                    )
-                )
+                def _record_current_tool_duration(
+                    completed_task: asyncio.Task[Any],
+                    *,
+                    name: str = fnc_call.name,
+                    started_at: float = started_at,
+                ) -> None:
+                    _record_tool_duration(completed_task, name=name, started_at=started_at)
+
+                task.add_done_callback(_record_current_tool_duration)
 
                 _set_activity_task_info(
                     task, speech_handle=speech_handle, function_call=fnc_call, inline_task=True
                 )
                 tasks.append(task)
-                task.add_done_callback(lambda task: tasks.remove(task))
+
+                def _remove_completed_task(completed_task: asyncio.Task[Any]) -> None:
+                    tasks.remove(completed_task)
+
+                task.add_done_callback(_remove_completed_task)
             except Exception as e:
                 # catching exceptions here because even though the function is asynchronous,
                 # errors such as missing or incompatible arguments can still occur at

--- a/tests/test_audio_recognition_shutdown.py
+++ b/tests/test_audio_recognition_shutdown.py
@@ -1,0 +1,36 @@
+import asyncio
+from contextlib import suppress
+from unittest.mock import MagicMock
+
+import pytest
+
+from livekit.agents.voice.audio_recognition import AudioRecognition
+
+
+@pytest.mark.asyncio
+async def test_aclose_ignores_pre_cancelled_end_of_turn_task() -> None:
+    """Regression for shutdown after user speech interrupts EOU detection."""
+
+    recognition = AudioRecognition(
+        MagicMock(),
+        hooks=MagicMock(),
+        stt=None,
+        vad=None,
+        turn_detection="manual",
+        min_endpointing_delay=0.1,
+        max_endpointing_delay=0.1,
+    )
+
+    async def pending_eou_task() -> None:
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(pending_eou_task())
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+    assert task.done()
+    assert task.cancelled()
+    recognition._end_of_turn_task = task
+
+    await asyncio.wait_for(recognition.aclose(), timeout=0.1)


### PR DESCRIPTION
## Summary
- Mirror upstream LiveKit `main` handling for cancelled shutdown tasks in `AudioRecognition.aclose()`
- Catch `asyncio.CancelledError` from cancelled `commit_user_turn` / EOU tasks so session close can continue to `session_end_callback`
- Keep fork-specific close trace logging and add a smoke regression test for the production stuck-ongoing failure shape
- Keep this PR based on `temp-1.4.6`; includes small ruff/type-check cleanup commits needed to make that base pass CI

## Context
PROD-1496 / call `04196320-7bbb-4c53-9273-1bde7444303a` stayed `ongoing` even though SIP/CDR showed a user hangup.

Logs showed shutdown reached:

```text
AudioRecognition.aclose end_of_turn_task await start
end_of_turn_task: done=true, cancelled=true
```

and then did **not** reach:

```text
AudioRecognition.aclose end_of_turn_task await done
AudioRecognition.aclose done
AgentActivity.aclose close_session done
session_end_callback_start
```

This is not a long wait on a pending task. Awaiting an already-cancelled asyncio task immediately raises `asyncio.CancelledError`. Since the surrounding close path mostly catches `Exception`, that cancellation can bypass the normal close/finalization path and prevent the DB terminal update.

## Upstream comparison
- `livekit-agents@1.4.6` has the vulnerable raw await shape:
  https://github.com/livekit/agents/blob/livekit-agents@1.4.6/livekit-agents/livekit/agents/voice/audio_recognition.py#L195-L210
- Upstream `main` now suppresses `CancelledError` for cancelled `commit_user_turn` and EOU tasks during `AudioRecognition.aclose()`:
  https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/audio_recognition.py#L450-L477

This PR follows the upstream `main` behavior, while preserving our fork's diagnostic close logs.

## Changes
- Wrap `commit_user_turn_atask` await in `try/except asyncio.CancelledError`
- Wrap `_end_of_turn_task` await in `try/except asyncio.CancelledError`
- Log the cancelled close task state so future shutdown traces are explicit
- Add `tests/test_audio_recognition_shutdown.py` to reproduce the cancelled EOU task shape
- Add CI cleanup commits for `temp-1.4.6` ruff/type-check issues unrelated to the shutdown bug

## Review note
The behavioral fix is in:

```text
livekit-agents/livekit/agents/voice/audio_recognition.py
tests/test_audio_recognition_shutdown.py
```

The other touched files are base-branch CI cleanup so this PR can be green against `temp-1.4.6`.

## Verification
- `PYTHONPATH=livekit-agents /Users/euichankim/Project/voxai/vox-mono/domains/voxai/agent-server/.venv/bin/python -m pytest tests/test_audio_recognition_shutdown.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/check_types.py`

## Downstream
- `fleek-fitness/voxai-agent-server#726` pins this PR's current head SHA: `78d5991f3678c03bdd3ce90bddc3753ba294c138`
