### PR TITLE
fix(voice): confirm VAD latency anchors with STT turns

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1508,8 +1508,6 @@ class AgentActivity(RecognitionHooks):
         else:
             self._stt_eos_received = True
 
-        self._last_eou_timestamp = speech_end_time
-
         self._session._update_user_state(
             "listening",
             last_speaking_time=speech_end_time,
@@ -1701,17 +1699,15 @@ class AgentActivity(RecognitionHooks):
             and not self._current_speech.interrupted
         )
         delayed_interruption_context = (
-            not current_speech_interruptible
+            not info.transcript_clock_suppressed
+            and not current_speech_interruptible
             and self._user_speech_started_during_interruptible_agent_speech
         )
 
         if (
             self.stt is not None
             and self._turn_detection != "manual"
-            and (
-                current_speech_interruptible
-                or self._user_speech_started_during_interruptible_agent_speech
-            )
+            and (current_speech_interruptible or delayed_interruption_context)
         ):
             # Dynamic min_interruption_words
             dyn_min_words = 0
@@ -1755,6 +1751,12 @@ class AgentActivity(RecognitionHooks):
                             reason="interruption_ignore_words",
                         )
                     return False
+
+        self._last_eou_timestamp = (
+            info.stopped_speaking_at
+            if not info.transcript_clock_suppressed and info.stopped_speaking_at is not None
+            else None
+        )
 
         old_task = self._user_turn_completed_atask
         self._user_turn_completed_atask = self._create_speech_task(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1485,11 +1485,8 @@ class AgentActivity(RecognitionHooks):
         if ev:
             speech_start_time = speech_start_time - ev.speech_duration
         current_speech = self._current_speech
-        started_during_agent_speech = current_speech is not None and not current_speech.interrupted
         self._user_speech_started_during_interruptible_agent_speech = (
-            started_during_agent_speech
-            and current_speech is not None
-            and current_speech.allow_interruptions
+            current_speech is not None and current_speech.allow_interruptions
         )
         self._session._update_user_state("speaking", last_speaking_time=speech_start_time)
         self._user_silence_event.clear()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1649,13 +1649,23 @@ class AgentActivity(RecognitionHooks):
     def _clear_user_speech_interruption_context(self) -> None:
         self._user_speech_started_during_interruptible_agent_speech = False
 
-    def _consume_delayed_interruption_turn(self, transcript: str, *, reason: str) -> bool:
+    def _consume_delayed_interruption_turn(self, info: _EndOfTurnInfo, *, reason: str) -> bool:
         self._cancel_preemptive_generation()
         self._last_eou_timestamp = None
         self._clear_user_speech_interruption_context()
-        logger.debug(
+        # Preserve the consumed transcript in chat history so the LLM has memory
+        # of a late user utterance even when we choose not to interrupt.
+        if info.new_transcript:
+            user_message = llm.ChatMessage(
+                role="user",
+                content=[info.new_transcript],
+                transcript_confidence=info.transcript_confidence,
+            )
+            self._agent._chat_ctx.items.append(user_message)
+            self._session._conversation_item_added(user_message)
+        logger.warning(
             "consuming delayed interruption transcript",
-            extra={"user_input": transcript, "reason": reason},
+            extra={"user_input": info.new_transcript, "reason": reason},
         )
         return True
 
@@ -1720,7 +1730,7 @@ class AgentActivity(RecognitionHooks):
                 # avoid interruption if the new_transcript is too short
                 if delayed_interruption_context:
                     return self._consume_delayed_interruption_turn(
-                        info.new_transcript,
+                        info,
                         reason="min_interruption_words",
                     )
                 return False
@@ -1733,7 +1743,7 @@ class AgentActivity(RecognitionHooks):
                     self._cancel_preemptive_generation()
                     if delayed_interruption_context:
                         return self._consume_delayed_interruption_turn(
-                            info.new_transcript,
+                            info,
                             reason="empty_interruption",
                         )
                     return False
@@ -1744,7 +1754,7 @@ class AgentActivity(RecognitionHooks):
                     self._cancel_preemptive_generation()
                     if delayed_interruption_context:
                         return self._consume_delayed_interruption_turn(
-                            info.new_transcript,
+                            info,
                             reason="interruption_ignore_words",
                         )
                     return False
@@ -1946,6 +1956,17 @@ class AgentActivity(RecognitionHooks):
                 metadata=metadata,
             )
             self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=eou_metrics))
+        else:
+            # Operators must be able to see when EOU metrics are dropped, otherwise a
+            # regression that mass-suppresses turns would silently zero out the
+            # response-latency dashboard.
+            logger.debug(
+                "skipping EOU metrics for suppressed transcript",
+                extra={
+                    "speech_id": speech_handle.id,
+                    "user_input": info.new_transcript,
+                },
+            )
 
     # AudioRecognition is calling this method to retrieve the chat context before running the TurnDetector model  # noqa: E501
     def retrieve_chat_ctx(self) -> llm.ChatContext:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -207,6 +207,7 @@ class AgentActivity(RecognitionHooks):
         # For response latency metrics tracking
         self._last_eou_timestamp: float | None = None
         self._agent_ttft_by_speech: dict[str, float] = {}
+        self._user_speech_started_during_interruptible_agent_speech = False
 
         self._drain_blocked_tasks: list[asyncio.Task[Any]] = []
         self._mcp_tools: list[mcp.MCPTool] = []
@@ -1483,6 +1484,13 @@ class AgentActivity(RecognitionHooks):
         speech_start_time = time.time()
         if ev:
             speech_start_time = speech_start_time - ev.speech_duration
+        current_speech = self._current_speech
+        started_during_agent_speech = current_speech is not None and not current_speech.interrupted
+        self._user_speech_started_during_interruptible_agent_speech = (
+            started_during_agent_speech
+            and current_speech is not None
+            and current_speech.allow_interruptions
+        )
         self._session._update_user_state("speaking", last_speaking_time=speech_start_time)
         self._user_silence_event.clear()
         self._stt_eos_received = False
@@ -1643,9 +1651,28 @@ class AgentActivity(RecognitionHooks):
             created_at=time.time(),
         )
 
+    def _clear_user_speech_interruption_context(self) -> None:
+        self._user_speech_started_during_interruptible_agent_speech = False
+
+    def _consume_delayed_interruption_turn(self, transcript: str, *, reason: str) -> bool:
+        self._cancel_preemptive_generation()
+        self._last_eou_timestamp = None
+        self._clear_user_speech_interruption_context()
+        logger.debug(
+            "consuming delayed interruption transcript",
+            extra={"user_input": transcript, "reason": reason},
+        )
+        return True
+
     def on_end_of_turn(self, info: _EndOfTurnInfo) -> bool:
         # IMPORTANT: This method is sync to avoid it being cancelled by the AudioRecognition
         # We explicitly create a new task here
+
+        if info.transcript_clock_suppressed:
+            # The transcript arrived after the endpointing window for the VAD speech
+            # that started this turn. Do not let the stale VAD timestamp anchor the
+            # next TTS response latency.
+            self._last_eou_timestamp = None
 
         if self._scheduling_paused:
             self._cancel_preemptive_generation()
@@ -1665,14 +1692,26 @@ class AgentActivity(RecognitionHooks):
                 self._session._conversation_item_added(user_message)
 
             # TODO(theomonnom): should we "forward" this new turn to the next agent/activity?
+            self._clear_user_speech_interruption_context()
             return True
+
+        current_speech_interruptible = (
+            self._current_speech is not None
+            and self._current_speech.allow_interruptions
+            and not self._current_speech.interrupted
+        )
+        delayed_interruption_context = (
+            not current_speech_interruptible
+            and self._user_speech_started_during_interruptible_agent_speech
+        )
 
         if (
             self.stt is not None
             and self._turn_detection != "manual"
-            and self._current_speech is not None
-            and self._current_speech.allow_interruptions
-            and not self._current_speech.interrupted
+            and (
+                current_speech_interruptible
+                or self._user_speech_started_during_interruptible_agent_speech
+            )
         ):
             # Dynamic min_interruption_words
             dyn_min_words = 0
@@ -1686,6 +1725,11 @@ class AgentActivity(RecognitionHooks):
             ):
                 self._cancel_preemptive_generation()
                 # avoid interruption if the new_transcript is too short
+                if delayed_interruption_context:
+                    return self._consume_delayed_interruption_turn(
+                        info.new_transcript,
+                        reason="min_interruption_words",
+                    )
                 return False
 
             # Interruption ignore words
@@ -1694,12 +1738,22 @@ class AgentActivity(RecognitionHooks):
 
                 if is_empty and dyn_min_words > 0:
                     self._cancel_preemptive_generation()
+                    if delayed_interruption_context:
+                        return self._consume_delayed_interruption_turn(
+                            info.new_transcript,
+                            reason="empty_interruption",
+                        )
                     return False
 
                 if (not is_empty) and _matches_ignore_words(
                     info.new_transcript, self._session.options.interruption_ignore_words
                 ):
                     self._cancel_preemptive_generation()
+                    if delayed_interruption_context:
+                        return self._consume_delayed_interruption_turn(
+                            info.new_transcript,
+                            reason="interruption_ignore_words",
+                        )
                     return False
 
         old_task = self._user_turn_completed_atask
@@ -1707,6 +1761,7 @@ class AgentActivity(RecognitionHooks):
             self._user_turn_completed_task(old_task, info),
             name="AgentActivity._user_turn_completed_task",
         )
+        self._clear_user_speech_interruption_context()
         return True
 
     @utils.log_exceptions(logger=logger)
@@ -1882,15 +1937,16 @@ class AgentActivity(RecognitionHooks):
                 model_name=self._turn_detection.model, model_provider=self._turn_detection.provider
             )
 
-        eou_metrics = EOUMetrics(
-            timestamp=time.time(),
-            end_of_utterance_delay=info.end_of_turn_delay or 0.0,
-            transcription_delay=info.transcription_delay or 0.0,
-            on_user_turn_completed_delay=on_user_turn_completed_delay,
-            speech_id=speech_handle.id,
-            metadata=metadata,
-        )
-        self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=eou_metrics))
+        if not info.transcript_clock_suppressed:
+            eou_metrics = EOUMetrics(
+                timestamp=time.time(),
+                end_of_utterance_delay=info.end_of_turn_delay or 0.0,
+                transcription_delay=info.transcription_delay or 0.0,
+                on_user_turn_completed_delay=on_user_turn_completed_delay,
+                speech_id=speech_handle.id,
+                metadata=metadata,
+            )
+            self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=eou_metrics))
 
     # AudioRecognition is calling this method to retrieve the chat context before running the TurnDetector model  # noqa: E501
     def retrieve_chat_ctx(self) -> llm.ChatContext:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -206,6 +206,7 @@ class AgentActivity(RecognitionHooks):
         self._dynamic_interruption = DynamicInterruptionManager(sess.options)
         # For response latency metrics tracking
         self._last_eou_timestamp: float | None = None
+        self._response_latency_anchors_by_speech: dict[str, float] = {}
         self._agent_ttft_by_speech: dict[str, float] = {}
         self._user_speech_started_during_interruptible_agent_speech = False
 
@@ -771,6 +772,33 @@ class AgentActivity(RecognitionHooks):
     def _wake_up_scheduling_task(self) -> None:
         self._q_updated.set()
 
+    def _response_latency_anchors(self) -> dict[str, float]:
+        anchors = getattr(self, "_response_latency_anchors_by_speech", None)
+        if anchors is None:
+            anchors = {}
+            self._response_latency_anchors_by_speech = anchors
+        return anchors
+
+    def _sync_latest_response_latency_anchor(self) -> None:
+        anchors = self._response_latency_anchors()
+        self._last_eou_timestamp = next(reversed(anchors.values()), None) if anchors else None
+
+    def _register_response_latency_anchor(
+        self, speech_handle: SpeechHandle, info: _EndOfTurnInfo
+    ) -> None:
+        if info.transcript_clock_suppressed or info.stopped_speaking_at is None:
+            return
+        if speech_handle.interrupted:
+            return
+
+        self._response_latency_anchors()[speech_handle.id] = info.stopped_speaking_at
+        self._sync_latest_response_latency_anchor()
+        speech_handle.add_done_callback(self._discard_response_latency_anchor)
+
+    def _discard_response_latency_anchor(self, speech_handle: SpeechHandle) -> None:
+        self._response_latency_anchors().pop(speech_handle.id, None)
+        self._sync_latest_response_latency_anchor()
+
     async def pause(self, *, blocked_tasks: list[asyncio.Task]) -> None:
         # `pause` must only be called by AgentSession
 
@@ -1295,19 +1323,27 @@ class AgentActivity(RecognitionHooks):
         if isinstance(ev, AgentLLMMetrics) and ev.speech_id and ev.agent_ttft is not None:
             self._agent_ttft_by_speech[ev.speech_id] = ev.agent_ttft
 
-        # Compute and emit response latency when TTS metrics arrive
-        if self._last_eou_timestamp is not None and isinstance(ev, TTSMetrics) and ev.ttfb > 0:
+        # Compute and emit response latency when the matching reply TTS metrics arrive.
+        if isinstance(ev, TTSMetrics) and ev.ttfb > 0:
             first_audio_timestamp = ev.timestamp - ev.duration + ev.ttfb
             speech_handle = _SpeechHandleContextVar.get(None)
-            speech_id = speech_handle.id if speech_handle else None
+            speech_id = ev.speech_id or (speech_handle.id if speech_handle else None)
+            eou_timestamp = (
+                self._response_latency_anchors().pop(speech_id, None) if speech_id else None
+            )
+            self._sync_latest_response_latency_anchor()
+            if eou_timestamp is None:
+                self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=ev))
+                return
+
             agent_ttft = self._agent_ttft_by_speech.get(speech_id) if speech_id else None
-            e2e_latency = first_audio_timestamp - self._last_eou_timestamp
+            e2e_latency = first_audio_timestamp - eou_timestamp
 
             response_latency_metrics = ResponseLatencyMetrics(
                 timestamp=time.time(),
                 speech_id=speech_id,
                 e2e_latency=e2e_latency,
-                eou_timestamp=self._last_eou_timestamp,
+                eou_timestamp=eou_timestamp,
                 first_audio_timestamp=first_audio_timestamp,
             )
             self._session.emit(
@@ -1319,7 +1355,6 @@ class AgentActivity(RecognitionHooks):
             )
 
             # Reset tracking for next response
-            self._last_eou_timestamp = None
             if speech_id and speech_id in self._agent_ttft_by_speech:
                 del self._agent_ttft_by_speech[speech_id]
             # Reset collision backoff at turn completion
@@ -1651,7 +1686,6 @@ class AgentActivity(RecognitionHooks):
 
     def _consume_delayed_interruption_turn(self, info: _EndOfTurnInfo, *, reason: str) -> bool:
         self._cancel_preemptive_generation()
-        self._last_eou_timestamp = None
         self._clear_user_speech_interruption_context()
         # Preserve the consumed transcript in chat history so the LLM has memory
         # of a late user utterance even when we choose not to interrupt.
@@ -1672,12 +1706,6 @@ class AgentActivity(RecognitionHooks):
     def on_end_of_turn(self, info: _EndOfTurnInfo) -> bool:
         # IMPORTANT: This method is sync to avoid it being cancelled by the AudioRecognition
         # We explicitly create a new task here
-
-        if info.transcript_clock_suppressed:
-            # The transcript arrived after the endpointing window for the VAD speech
-            # that started this turn. Do not let the stale VAD timestamp anchor the
-            # next TTS response latency.
-            self._last_eou_timestamp = None
 
         if self._scheduling_paused:
             self._cancel_preemptive_generation()
@@ -1759,12 +1787,6 @@ class AgentActivity(RecognitionHooks):
                             reason="interruption_ignore_words",
                         )
                     return False
-
-        self._last_eou_timestamp = (
-            info.stopped_speaking_at
-            if not info.transcript_clock_suppressed and info.stopped_speaking_at is not None
-            else None
-        )
 
         old_task = self._user_turn_completed_atask
         self._user_turn_completed_atask = self._create_speech_task(
@@ -1932,12 +1954,15 @@ class AgentActivity(RecognitionHooks):
                 input_details=InputDetails(modality="audio"),
             )
 
-        if self._user_turn_completed_atask != asyncio.current_task():
+        current_user_turn_task = self._user_turn_completed_atask == asyncio.current_task()
+        if not current_user_turn_task:
             # If a new user turn has already started, interrupt this one since it's now outdated
             # (We still create the SpeechHandle and the generate_reply coroutine, otherwise we may
             # lose data like the beginning of a user speech).
             # await the interrupt to make sure user message is added to the chat context before the new task starts
             await speech_handle.interrupt()
+        else:
+            self._register_response_latency_anchor(speech_handle, info)
 
         metadata: Metadata | None = None
         if isinstance(self._turn_detection, str):

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1714,6 +1714,7 @@ class AgentActivity(RecognitionHooks):
         if (
             self.stt is not None
             and self._turn_detection != "manual"
+            and not info.transcript_clock_suppressed
             and (current_speech_interruptible or delayed_interruption_context)
         ):
             # Dynamic min_interruption_words

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -36,6 +36,7 @@ class _EndOfTurnInfo:
     """If True, a reply was already triggered and should be skipped after end of turn detection."""
     new_transcript: str
     transcript_confidence: float
+    transcript_clock_suppressed: bool
 
     # metrics report
     started_speaking_at: float | None
@@ -131,6 +132,7 @@ class AudioRecognition:
         self._last_final_transcript_time: float | None = None
         self._last_speaking_time: float | None = None
         self._speech_start_time: float | None = None
+        self._final_transcript_clock_suppressed = False
 
         # used for manual commit_user_turn
         self._final_transcript_received = asyncio.Event()
@@ -294,6 +296,7 @@ class AudioRecognition:
         self._audio_interim_transcript = ""
         self._audio_preflight_transcript = ""
         self._final_transcript_confidence = []
+        self._final_transcript_clock_suppressed = False
         self._user_turn_committed = False
 
         # reset stt to clear the buffer from previous user turn
@@ -442,7 +445,10 @@ class AudioRecognition:
                 extra["transcript_delay"] = time.time() - self._last_speaking_time
             logger.debug("received user transcript", extra=extra)
 
-            self._last_final_transcript_time = time.time()
+            if self._should_advance_final_transcript_clock():
+                self._last_final_transcript_time = time.time()
+            else:
+                self._final_transcript_clock_suppressed = True
             self._audio_transcript += f" {transcript}"
             self._audio_transcript = self._audio_transcript.lstrip()
             self._final_transcript_confidence.append(confidence)
@@ -503,7 +509,10 @@ class AudioRecognition:
             )
 
             # still need to increment it as it's used for turn detection,
-            self._last_final_transcript_time = time.time()
+            if self._should_advance_final_transcript_clock():
+                self._last_final_transcript_time = time.time()
+            else:
+                self._final_transcript_clock_suppressed = True
             # preflight transcript includes all pre-committed transcripts (including final transcript from the previous STT run)
             self._audio_preflight_transcript = (self._audio_transcript + " " + transcript).lstrip()
             self._audio_interim_transcript = transcript
@@ -548,6 +557,7 @@ class AudioRecognition:
                 self._hooks.on_start_of_speech(None)
 
             self._speaking = True
+            self._final_transcript_clock_suppressed = False
             if self._speech_start_time is None:
                 self._speech_start_time = time.time()
             self._last_speaking_time = time.time()
@@ -564,6 +574,7 @@ class AudioRecognition:
                 self._hooks.on_start_of_speech(ev)
 
             self._speaking = True
+            self._final_transcript_clock_suppressed = False
 
             if self._end_of_turn_task is not None:
                 self._end_of_turn_task.cancel()
@@ -608,6 +619,7 @@ class AudioRecognition:
             last_speaking_time: float | None = None,
             last_final_transcript_time: float | None = None,
             speech_start_time: float | None = None,
+            transcript_clock_suppressed: bool = False,
         ) -> None:
             endpointing_delay = self._min_endpointing_delay
             user_turn_span = self._ensure_user_turn_span()
@@ -699,7 +711,8 @@ class AudioRecognition:
             # sometimes, we can't calculate the metrics because VAD was unreliable.
             # in this case, we just ignore the calculation, it's better than providing likely wrong values
             if (
-                last_final_transcript_time is not None
+                not transcript_clock_suppressed
+                and last_final_transcript_time is not None
                 and last_speaking_time is not None
                 and speech_start_time is not None
             ):
@@ -713,7 +726,12 @@ class AudioRecognition:
                     skip_reply=skip_reply,
                     new_transcript=self._audio_transcript,
                     transcript_confidence=confidence_avg,
-                    transcription_delay=transcription_delay or 0,
+                    transcript_clock_suppressed=transcript_clock_suppressed,
+                    transcription_delay=(
+                        transcription_delay
+                        if transcription_delay is not None or transcript_clock_suppressed
+                        else 0
+                    ),
                     end_of_turn_delay=end_of_turn_delay,
                     started_speaking_at=started_speaking_at,
                     stopped_speaking_at=stopped_speaking_at,
@@ -735,6 +753,7 @@ class AudioRecognition:
                 self._audio_transcript = ""
                 self._final_transcript_confidence = []
                 self._last_final_transcript_time = None
+                self._final_transcript_clock_suppressed = False
                 # concurrent user speech might have changed it
                 # only reset if there is no new speech
                 if self._last_speaking_time == last_speaking_time:
@@ -753,8 +772,16 @@ class AudioRecognition:
                 self._last_speaking_time,
                 self._last_final_transcript_time,
                 self._speech_start_time,
+                self._final_transcript_clock_suppressed,
             )
         )
+
+    def _should_advance_final_transcript_clock(self) -> bool:
+        if self._last_speaking_time is None:
+            return True
+        if self._speaking:
+            return True
+        return time.time() - self._last_speaking_time <= self._max_endpointing_delay
 
     @utils.log_exceptions(logger=logger)
     async def _stt_task(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -445,10 +445,7 @@ class AudioRecognition:
                 extra["transcript_delay"] = time.time() - self._last_speaking_time
             logger.debug("received user transcript", extra=extra)
 
-            if self._should_advance_final_transcript_clock():
-                self._last_final_transcript_time = time.time()
-            else:
-                self._final_transcript_clock_suppressed = True
+            self._record_final_transcript_time()
             self._audio_transcript += f" {transcript}"
             self._audio_transcript = self._audio_transcript.lstrip()
             self._final_transcript_confidence.append(confidence)
@@ -508,11 +505,7 @@ class AudioRecognition:
                 extra={"user_transcript": transcript, "language": self._last_language},
             )
 
-            # still need to increment it as it's used for turn detection,
-            if self._should_advance_final_transcript_clock():
-                self._last_final_transcript_time = time.time()
-            else:
-                self._final_transcript_clock_suppressed = True
+            self._record_final_transcript_time()
             # preflight transcript includes all pre-committed transcripts (including final transcript from the previous STT run)
             self._audio_preflight_transcript = (self._audio_transcript + " " + transcript).lstrip()
             self._audio_interim_transcript = transcript
@@ -782,6 +775,11 @@ class AudioRecognition:
         if self._speaking:
             return True
         return time.time() - self._last_speaking_time <= self._max_endpointing_delay
+
+    def _record_final_transcript_time(self) -> None:
+        if not self._should_advance_final_transcript_clock():
+            self._final_transcript_clock_suppressed = True
+        self._last_final_transcript_time = time.time()
 
     @utils.log_exceptions(logger=logger)
     async def _stt_task(

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -746,13 +746,15 @@ class AudioRecognition:
                 self._audio_transcript = ""
                 self._final_transcript_confidence = []
                 self._last_final_transcript_time = None
-                self._final_transcript_clock_suppressed = False
                 # concurrent user speech might have changed it
                 # only reset if there is no new speech
                 if self._last_speaking_time == last_speaking_time:
                     self._speech_start_time = None
                     self._last_speaking_time = None
 
+            # Always reset the suppression flag so a non-committed turn does not
+            # leak its suspect-clock state into the next EOU bounce.
+            self._final_transcript_clock_suppressed = False
             self._user_turn_committed = False
 
         if self._end_of_turn_task is not None:

--- a/tests/test_prod1419_backchannel_latency.py
+++ b/tests/test_prod1419_backchannel_latency.py
@@ -37,6 +37,25 @@ def test_final_transcript_clock_advances_while_user_is_speaking() -> None:
     assert recognition._should_advance_final_transcript_clock() is True
 
 
+def test_suppressed_final_transcript_still_updates_recency_clock() -> None:
+    recognition = AudioRecognition(
+        SimpleNamespace(),
+        hooks=SimpleNamespace(),
+        stt=None,
+        vad=SimpleNamespace(),
+        turn_detection="vad",
+        min_endpointing_delay=0.1,
+        max_endpointing_delay=0.5,
+    )
+    recognition._last_speaking_time = time.time() - 1.0
+    recognition._speaking = False
+
+    recognition._record_final_transcript_time()
+
+    assert recognition._final_transcript_clock_suppressed is True
+    assert recognition._last_final_transcript_time is not None
+
+
 def _activity_for_end_of_turn() -> tuple[AgentActivity, object]:
     activity = AgentActivity.__new__(AgentActivity)
     activity._agent = SimpleNamespace(stt=object())

--- a/tests/test_prod1419_backchannel_latency.py
+++ b/tests/test_prod1419_backchannel_latency.py
@@ -455,9 +455,9 @@ def test_response_latency_waits_for_matching_reply_tts_metrics() -> None:
 
     activity._on_metrics_collected(_tts_metrics(speech_id="unrelated-speech"))
 
-    assert not any(
-        isinstance(payload.metrics, ResponseLatencyMetrics) for _, payload in emitted
-    ), emitted
+    assert not any(isinstance(payload.metrics, ResponseLatencyMetrics) for _, payload in emitted), (
+        emitted
+    )
     assert activity._response_latency_anchors_by_speech == {speech_handle.id: 2.0}
 
     activity._on_metrics_collected(_tts_metrics(speech_id=speech_handle.id))

--- a/tests/test_prod1419_backchannel_latency.py
+++ b/tests/test_prod1419_backchannel_latency.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from types import SimpleNamespace
 
@@ -56,15 +57,24 @@ def test_suppressed_final_transcript_still_updates_recency_clock() -> None:
     assert recognition._last_final_transcript_time is not None
 
 
-def _activity_for_end_of_turn() -> tuple[AgentActivity, object]:
+def _activity_for_end_of_turn(
+    *,
+    min_interruption_words: int = 0,
+    dyn_min_words: int = 0,
+) -> tuple[AgentActivity, object, list[object]]:
     activity = AgentActivity.__new__(AgentActivity)
-    activity._agent = SimpleNamespace(stt=object())
+    chat_items: list[object] = []
+    activity._agent = SimpleNamespace(
+        stt=object(),
+        _chat_ctx=SimpleNamespace(items=chat_items),
+    )
     activity._session = SimpleNamespace(
         options=SimpleNamespace(
-            min_interruption_words=0,
+            min_interruption_words=min_interruption_words,
             interruption_ignore_words=["네", "예"],
         ),
         _closing=False,
+        _conversation_item_added=lambda *a, **k: None,
     )
     activity._turn_detection = "vad"
     activity._current_speech = None
@@ -74,7 +84,7 @@ def _activity_for_end_of_turn() -> tuple[AgentActivity, object]:
     activity._user_turn_completed_atask = None
     activity._user_speech_started_during_interruptible_agent_speech = True
     activity._dynamic_interruption = SimpleNamespace(
-        get_current_min_interruption_words=lambda: 0,
+        get_current_min_interruption_words=lambda: dyn_min_words,
     )
     task = object()
 
@@ -83,7 +93,7 @@ def _activity_for_end_of_turn() -> tuple[AgentActivity, object]:
         return task
 
     activity._create_speech_task = create_speech_task
-    return activity, task
+    return activity, task, chat_items
 
 
 def test_vad_end_does_not_create_response_latency_anchor() -> None:
@@ -126,7 +136,7 @@ def test_vad_start_keeps_context_when_speech_was_already_interrupted() -> None:
 
 
 def test_suppressed_transcript_commits_without_latency_anchor() -> None:
-    activity, task = _activity_for_end_of_turn()
+    activity, task, _ = _activity_for_end_of_turn()
 
     committed = activity.on_end_of_turn(
         _EndOfTurnInfo(
@@ -148,7 +158,7 @@ def test_suppressed_transcript_commits_without_latency_anchor() -> None:
 
 
 def test_committed_turn_sets_response_latency_anchor_from_reliable_stop_time() -> None:
-    activity, task = _activity_for_end_of_turn()
+    activity, task, _ = _activity_for_end_of_turn()
     activity._user_speech_started_during_interruptible_agent_speech = False
 
     committed = activity.on_end_of_turn(
@@ -170,7 +180,7 @@ def test_committed_turn_sets_response_latency_anchor_from_reliable_stop_time() -
 
 
 def test_non_suppressed_delayed_ignored_backchannel_is_consumed_without_reply_or_anchor() -> None:
-    activity, _ = _activity_for_end_of_turn()
+    activity, _, chat_items = _activity_for_end_of_turn()
 
     committed = activity.on_end_of_turn(
         _EndOfTurnInfo(
@@ -189,3 +199,138 @@ def test_non_suppressed_delayed_ignored_backchannel_is_consumed_without_reply_or
     assert activity._user_turn_completed_atask is None
     assert activity._last_eou_timestamp is None
     assert activity._user_speech_started_during_interruptible_agent_speech is False
+    assert len(chat_items) == 1
+    assert chat_items[0].role == "user"
+
+
+def test_delayed_short_transcript_consumed_via_min_interruption_words_branch() -> None:
+    activity, _, chat_items = _activity_for_end_of_turn(dyn_min_words=3)
+    activity._current_speech = SimpleNamespace(allow_interruptions=False, interrupted=False)
+
+    committed = activity.on_end_of_turn(
+        _EndOfTurnInfo(
+            skip_reply=False,
+            new_transcript="아",
+            transcript_confidence=1.0,
+            transcript_clock_suppressed=False,
+            started_speaking_at=400.0,
+            stopped_speaking_at=456.0,
+            transcription_delay=0.1,
+            end_of_turn_delay=0.2,
+        )
+    )
+
+    assert committed is True
+    assert activity._user_turn_completed_atask is None
+    assert activity._last_eou_timestamp is None
+    assert activity._user_speech_started_during_interruptible_agent_speech is False
+    assert len(chat_items) == 1
+    assert chat_items[0].text_content == "아"
+
+
+def test_delayed_empty_transcript_consumed_via_empty_interruption_branch() -> None:
+    activity, _, chat_items = _activity_for_end_of_turn(dyn_min_words=2)
+    activity._current_speech = SimpleNamespace(allow_interruptions=False, interrupted=False)
+
+    committed = activity.on_end_of_turn(
+        _EndOfTurnInfo(
+            skip_reply=False,
+            new_transcript="",
+            transcript_confidence=0.0,
+            transcript_clock_suppressed=False,
+            started_speaking_at=400.0,
+            stopped_speaking_at=456.0,
+            transcription_delay=0.1,
+            end_of_turn_delay=0.2,
+        )
+    )
+
+    assert committed is True
+    assert activity._user_turn_completed_atask is None
+    assert activity._last_eou_timestamp is None
+    assert activity._user_speech_started_during_interruptible_agent_speech is False
+    # Empty transcript should not pollute chat history.
+    assert chat_items == []
+
+
+def _build_user_turn_completed_activity(
+    emitted: list[tuple[str, object]],
+) -> AgentActivity:
+    activity = AgentActivity.__new__(AgentActivity)
+    # `llm` is a property reading from `_agent.llm`; setting a non-NotGiven value
+    # makes `is_given` return True so the property resolves to a real object that
+    # is neither None nor a RealtimeModel — both early-return gates we must clear
+    # to reach the metrics emit site.
+    activity._agent = SimpleNamespace(
+        chat_ctx=SimpleNamespace(copy=lambda: SimpleNamespace(items=[])),
+        on_user_turn_completed=_async_noop,
+        _chat_ctx=SimpleNamespace(items=[]),
+        llm=SimpleNamespace(),
+    )
+    activity._session = SimpleNamespace(
+        emit=lambda evt, payload: emitted.append((evt, payload)),
+        _closing=False,
+        _conversation_item_added=lambda *a, **k: None,
+        llm=None,
+    )
+    activity._rt_session = None
+    activity._current_speech = None
+    activity._scheduling_paused = False
+    activity._preemptive_generation = None
+    activity._turn_detection = "vad"
+    speech_handle = SimpleNamespace(id="test-speech", interrupt=_async_noop)
+    activity._generate_reply = lambda **kwargs: speech_handle
+    activity._interrupt_background_speeches = lambda force=False: []
+    return activity
+
+
+async def _async_noop(*args: object, **kwargs: object) -> None:
+    return None
+
+
+def test_metrics_collected_emitted_when_clock_not_suppressed() -> None:
+    emitted: list[tuple[str, object]] = []
+    activity = _build_user_turn_completed_activity(emitted)
+
+    info = _EndOfTurnInfo(
+        skip_reply=False,
+        new_transcript="안녕하세요",
+        transcript_confidence=1.0,
+        transcript_clock_suppressed=False,
+        started_speaking_at=1.0,
+        stopped_speaking_at=2.0,
+        transcription_delay=0.1,
+        end_of_turn_delay=0.2,
+    )
+
+    async def run() -> None:
+        activity._user_turn_completed_atask = asyncio.current_task()
+        await activity._user_turn_completed_task(None, info)
+
+    asyncio.run(run())
+
+    assert any(evt == "metrics_collected" for evt, _ in emitted), emitted
+
+
+def test_metrics_collected_suppressed_when_clock_suppressed() -> None:
+    emitted: list[tuple[str, object]] = []
+    activity = _build_user_turn_completed_activity(emitted)
+
+    info = _EndOfTurnInfo(
+        skip_reply=False,
+        new_transcript="네",
+        transcript_confidence=1.0,
+        transcript_clock_suppressed=True,
+        started_speaking_at=None,
+        stopped_speaking_at=None,
+        transcription_delay=None,
+        end_of_turn_delay=None,
+    )
+
+    async def run() -> None:
+        activity._user_turn_completed_atask = asyncio.current_task()
+        await activity._user_turn_completed_task(None, info)
+
+    asyncio.run(run())
+
+    assert not any(evt == "metrics_collected" for evt, _ in emitted), emitted

--- a/tests/test_prod1419_backchannel_latency.py
+++ b/tests/test_prod1419_backchannel_latency.py
@@ -157,6 +157,30 @@ def test_suppressed_transcript_commits_without_latency_anchor() -> None:
     assert activity._user_speech_started_during_interruptible_agent_speech is False
 
 
+def test_suppressed_transcript_bypasses_interruption_filters() -> None:
+    activity, task, chat_items = _activity_for_end_of_turn(dyn_min_words=3)
+    activity._current_speech = SimpleNamespace(allow_interruptions=True, interrupted=False)
+
+    committed = activity.on_end_of_turn(
+        _EndOfTurnInfo(
+            skip_reply=False,
+            new_transcript="네",
+            transcript_confidence=1.0,
+            transcript_clock_suppressed=True,
+            started_speaking_at=None,
+            stopped_speaking_at=None,
+            transcription_delay=None,
+            end_of_turn_delay=None,
+        )
+    )
+
+    assert committed is True
+    assert activity._user_turn_completed_atask is task
+    assert activity._last_eou_timestamp is None
+    assert activity._user_speech_started_during_interruptible_agent_speech is False
+    assert chat_items == []
+
+
 def test_committed_turn_sets_response_latency_anchor_from_reliable_stop_time() -> None:
     activity, task, _ = _activity_for_end_of_turn()
     activity._user_speech_started_during_interruptible_agent_speech = False

--- a/tests/test_prod1419_backchannel_latency.py
+++ b/tests/test_prod1419_backchannel_latency.py
@@ -106,6 +106,25 @@ def test_vad_end_does_not_create_response_latency_anchor() -> None:
     assert isinstance(updates[-1][1]["last_speaking_time"], float)
 
 
+def test_vad_start_keeps_context_when_speech_was_already_interrupted() -> None:
+    updates = []
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._current_speech = SimpleNamespace(interrupted=True, allow_interruptions=True)
+    activity._session = SimpleNamespace(
+        _update_user_state=lambda state, **kwargs: updates.append((state, kwargs))
+    )
+    activity._user_silence_event = SimpleNamespace(clear=lambda: None)
+    activity._stt_eos_received = True
+    activity._dynamic_interruption = SimpleNamespace(on_user_speech_started=lambda: None)
+    activity._false_interruption_timer = None
+
+    activity.on_start_of_speech(None)
+
+    assert activity._user_speech_started_during_interruptible_agent_speech is True
+    assert activity._stt_eos_received is False
+    assert updates[-1][0] == "speaking"
+
+
 def test_suppressed_transcript_commits_without_latency_anchor() -> None:
     activity, task = _activity_for_end_of_turn()
 

--- a/tests/test_prod1419_backchannel_latency.py
+++ b/tests/test_prod1419_backchannel_latency.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from types import SimpleNamespace
 
+from livekit.agents.metrics import ResponseLatencyMetrics, TTSMetrics
 from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnInfo
 
@@ -80,7 +81,9 @@ def _activity_for_end_of_turn(
     activity._current_speech = None
     activity._scheduling_paused = False
     activity._preemptive_generation = None
-    activity._last_eou_timestamp = 123.0
+    activity._last_eou_timestamp = None
+    activity._response_latency_anchors_by_speech = {}
+    activity._agent_ttft_by_speech = {}
     activity._user_turn_completed_atask = None
     activity._user_speech_started_during_interruptible_agent_speech = True
     activity._dynamic_interruption = SimpleNamespace(
@@ -181,7 +184,7 @@ def test_suppressed_transcript_bypasses_interruption_filters() -> None:
     assert chat_items == []
 
 
-def test_committed_turn_sets_response_latency_anchor_from_reliable_stop_time() -> None:
+def test_committed_turn_waits_for_reply_before_setting_response_latency_anchor() -> None:
     activity, task, _ = _activity_for_end_of_turn()
     activity._user_speech_started_during_interruptible_agent_speech = False
 
@@ -200,7 +203,55 @@ def test_committed_turn_sets_response_latency_anchor_from_reliable_stop_time() -
 
     assert committed is True
     assert activity._user_turn_completed_atask is task
-    assert activity._last_eou_timestamp == 456.0
+    assert activity._last_eou_timestamp is None
+    assert activity._response_latency_anchors_by_speech == {}
+
+
+def test_skip_reply_turn_does_not_set_response_latency_anchor() -> None:
+    activity, task, _ = _activity_for_end_of_turn()
+    activity._user_speech_started_during_interruptible_agent_speech = False
+
+    committed = activity.on_end_of_turn(
+        _EndOfTurnInfo(
+            skip_reply=True,
+            new_transcript="예약 문의요",
+            transcript_confidence=1.0,
+            transcript_clock_suppressed=False,
+            started_speaking_at=400.0,
+            stopped_speaking_at=456.0,
+            transcription_delay=0.1,
+            end_of_turn_delay=0.2,
+        )
+    )
+
+    assert committed is True
+    assert activity._user_turn_completed_atask is task
+    assert activity._last_eou_timestamp is None
+    assert activity._response_latency_anchors_by_speech == {}
+
+
+def test_non_interruptible_no_reply_turn_does_not_set_response_latency_anchor() -> None:
+    activity, task, _ = _activity_for_end_of_turn()
+    activity._current_speech = SimpleNamespace(allow_interruptions=False, interrupted=False)
+    activity._user_speech_started_during_interruptible_agent_speech = False
+
+    committed = activity.on_end_of_turn(
+        _EndOfTurnInfo(
+            skip_reply=False,
+            new_transcript="예약 문의요",
+            transcript_confidence=1.0,
+            transcript_clock_suppressed=False,
+            started_speaking_at=400.0,
+            stopped_speaking_at=456.0,
+            transcription_delay=0.1,
+            end_of_turn_delay=0.2,
+        )
+    )
+
+    assert committed is True
+    assert activity._user_turn_completed_atask is task
+    assert activity._last_eou_timestamp is None
+    assert activity._response_latency_anchors_by_speech == {}
 
 
 def test_non_suppressed_delayed_ignored_backchannel_is_consumed_without_reply_or_anchor() -> None:
@@ -277,9 +328,22 @@ def test_delayed_empty_transcript_consumed_via_empty_interruption_branch() -> No
     assert chat_items == []
 
 
+class _TestSpeechHandle:
+    def __init__(self, speech_id: str = "test-speech") -> None:
+        self.id = speech_id
+        self.interrupted = False
+        self.done_callbacks = []
+
+    async def interrupt(self) -> None:
+        self.interrupted = True
+
+    def add_done_callback(self, callback) -> None:  # noqa: ANN001
+        self.done_callbacks.append(callback)
+
+
 def _build_user_turn_completed_activity(
     emitted: list[tuple[str, object]],
-) -> AgentActivity:
+) -> tuple[AgentActivity, _TestSpeechHandle]:
     activity = AgentActivity.__new__(AgentActivity)
     # `llm` is a property reading from `_agent.llm`; setting a non-NotGiven value
     # makes `is_given` return True so the property resolves to a real object that
@@ -302,10 +366,14 @@ def _build_user_turn_completed_activity(
     activity._scheduling_paused = False
     activity._preemptive_generation = None
     activity._turn_detection = "vad"
-    speech_handle = SimpleNamespace(id="test-speech", interrupt=_async_noop)
+    activity._last_eou_timestamp = None
+    activity._response_latency_anchors_by_speech = {}
+    activity._agent_ttft_by_speech = {}
+    activity._dynamic_interruption = SimpleNamespace(reset_collisions=lambda: None)
+    speech_handle = _TestSpeechHandle()
     activity._generate_reply = lambda **kwargs: speech_handle
     activity._interrupt_background_speeches = lambda force=False: []
-    return activity
+    return activity, speech_handle
 
 
 async def _async_noop(*args: object, **kwargs: object) -> None:
@@ -314,7 +382,7 @@ async def _async_noop(*args: object, **kwargs: object) -> None:
 
 def test_metrics_collected_emitted_when_clock_not_suppressed() -> None:
     emitted: list[tuple[str, object]] = []
-    activity = _build_user_turn_completed_activity(emitted)
+    activity, speech_handle = _build_user_turn_completed_activity(emitted)
 
     info = _EndOfTurnInfo(
         skip_reply=False,
@@ -334,11 +402,13 @@ def test_metrics_collected_emitted_when_clock_not_suppressed() -> None:
     asyncio.run(run())
 
     assert any(evt == "metrics_collected" for evt, _ in emitted), emitted
+    assert activity._last_eou_timestamp == 2.0
+    assert activity._response_latency_anchors_by_speech == {speech_handle.id: 2.0}
 
 
 def test_metrics_collected_suppressed_when_clock_suppressed() -> None:
     emitted: list[tuple[str, object]] = []
-    activity = _build_user_turn_completed_activity(emitted)
+    activity, _ = _build_user_turn_completed_activity(emitted)
 
     info = _EndOfTurnInfo(
         skip_reply=False,
@@ -358,3 +428,47 @@ def test_metrics_collected_suppressed_when_clock_suppressed() -> None:
     asyncio.run(run())
 
     assert not any(evt == "metrics_collected" for evt, _ in emitted), emitted
+    assert activity._last_eou_timestamp is None
+    assert activity._response_latency_anchors_by_speech == {}
+
+
+def _tts_metrics(*, speech_id: str, timestamp: float = 10.0) -> TTSMetrics:
+    return TTSMetrics(
+        label="test-tts",
+        request_id=f"tts-{speech_id}",
+        timestamp=timestamp,
+        ttfb=0.2,
+        duration=1.0,
+        audio_duration=1.0,
+        cancelled=False,
+        characters_count=10,
+        streamed=True,
+        speech_id=speech_id,
+    )
+
+
+def test_response_latency_waits_for_matching_reply_tts_metrics() -> None:
+    emitted: list[tuple[str, object]] = []
+    activity, speech_handle = _build_user_turn_completed_activity(emitted)
+    activity._response_latency_anchors_by_speech[speech_handle.id] = 2.0
+    activity._last_eou_timestamp = 2.0
+
+    activity._on_metrics_collected(_tts_metrics(speech_id="unrelated-speech"))
+
+    assert not any(
+        isinstance(payload.metrics, ResponseLatencyMetrics) for _, payload in emitted
+    ), emitted
+    assert activity._response_latency_anchors_by_speech == {speech_handle.id: 2.0}
+
+    activity._on_metrics_collected(_tts_metrics(speech_id=speech_handle.id))
+
+    response_latency = [
+        payload.metrics
+        for _, payload in emitted
+        if isinstance(payload.metrics, ResponseLatencyMetrics)
+    ]
+    assert len(response_latency) == 1
+    assert response_latency[0].speech_id == speech_handle.id
+    assert response_latency[0].eou_timestamp == 2.0
+    assert activity._last_eou_timestamp is None
+    assert activity._response_latency_anchors_by_speech == {}

--- a/tests/test_prod1419_backchannel_latency.py
+++ b/tests/test_prod1419_backchannel_latency.py
@@ -37,7 +37,7 @@ def test_final_transcript_clock_advances_while_user_is_speaking() -> None:
     assert recognition._should_advance_final_transcript_clock() is True
 
 
-def test_delayed_ignored_backchannel_is_consumed_without_reply_or_e2e_anchor() -> None:
+def _activity_for_end_of_turn() -> tuple[AgentActivity, object]:
     activity = AgentActivity.__new__(AgentActivity)
     activity._agent = SimpleNamespace(stt=object())
     activity._session = SimpleNamespace(
@@ -57,6 +57,38 @@ def test_delayed_ignored_backchannel_is_consumed_without_reply_or_e2e_anchor() -
     activity._dynamic_interruption = SimpleNamespace(
         get_current_min_interruption_words=lambda: 0,
     )
+    task = object()
+
+    def create_speech_task(coro, *, speech_handle=None, name=None):  # noqa: ANN001
+        coro.close()
+        return task
+
+    activity._create_speech_task = create_speech_task
+    return activity, task
+
+
+def test_vad_end_does_not_create_response_latency_anchor() -> None:
+    updates = []
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._session = SimpleNamespace(
+        options=SimpleNamespace(false_interruption_timeout=None),
+        _update_user_state=lambda state, **kwargs: updates.append((state, kwargs)),
+    )
+    activity._user_silence_event = SimpleNamespace(set=lambda: None)
+    activity._dynamic_interruption = SimpleNamespace(on_user_speech_ended=lambda: None)
+    activity._paused_speech = None
+    activity._stt_eos_received = False
+    activity._last_eou_timestamp = None
+
+    activity.on_end_of_speech(None)
+
+    assert activity._last_eou_timestamp is None
+    assert updates[-1][0] == "listening"
+    assert isinstance(updates[-1][1]["last_speaking_time"], float)
+
+
+def test_suppressed_transcript_commits_without_latency_anchor() -> None:
+    activity, task = _activity_for_end_of_turn()
 
     committed = activity.on_end_of_turn(
         _EndOfTurnInfo(
@@ -68,6 +100,50 @@ def test_delayed_ignored_backchannel_is_consumed_without_reply_or_e2e_anchor() -
             stopped_speaking_at=None,
             transcription_delay=None,
             end_of_turn_delay=None,
+        )
+    )
+
+    assert committed is True
+    assert activity._user_turn_completed_atask is task
+    assert activity._last_eou_timestamp is None
+    assert activity._user_speech_started_during_interruptible_agent_speech is False
+
+
+def test_committed_turn_sets_response_latency_anchor_from_reliable_stop_time() -> None:
+    activity, task = _activity_for_end_of_turn()
+    activity._user_speech_started_during_interruptible_agent_speech = False
+
+    committed = activity.on_end_of_turn(
+        _EndOfTurnInfo(
+            skip_reply=False,
+            new_transcript="예약 문의요",
+            transcript_confidence=1.0,
+            transcript_clock_suppressed=False,
+            started_speaking_at=400.0,
+            stopped_speaking_at=456.0,
+            transcription_delay=0.1,
+            end_of_turn_delay=0.2,
+        )
+    )
+
+    assert committed is True
+    assert activity._user_turn_completed_atask is task
+    assert activity._last_eou_timestamp == 456.0
+
+
+def test_non_suppressed_delayed_ignored_backchannel_is_consumed_without_reply_or_anchor() -> None:
+    activity, _ = _activity_for_end_of_turn()
+
+    committed = activity.on_end_of_turn(
+        _EndOfTurnInfo(
+            skip_reply=False,
+            new_transcript="네",
+            transcript_confidence=1.0,
+            transcript_clock_suppressed=False,
+            started_speaking_at=400.0,
+            stopped_speaking_at=456.0,
+            transcription_delay=0.1,
+            end_of_turn_delay=0.2,
         )
     )
 

--- a/tests/test_prod1419_backchannel_latency.py
+++ b/tests/test_prod1419_backchannel_latency.py
@@ -1,0 +1,77 @@
+import time
+from types import SimpleNamespace
+
+from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnInfo
+
+
+def test_final_transcript_clock_does_not_advance_after_endpointing_window() -> None:
+    recognition = AudioRecognition(
+        SimpleNamespace(),
+        hooks=SimpleNamespace(),
+        stt=None,
+        vad=SimpleNamespace(),
+        turn_detection="vad",
+        min_endpointing_delay=0.1,
+        max_endpointing_delay=0.5,
+    )
+    recognition._last_speaking_time = time.time() - 1.0
+    recognition._speaking = False
+
+    assert recognition._should_advance_final_transcript_clock() is False
+
+
+def test_final_transcript_clock_advances_while_user_is_speaking() -> None:
+    recognition = AudioRecognition(
+        SimpleNamespace(),
+        hooks=SimpleNamespace(),
+        stt=None,
+        vad=SimpleNamespace(),
+        turn_detection="vad",
+        min_endpointing_delay=0.1,
+        max_endpointing_delay=0.5,
+    )
+    recognition._last_speaking_time = time.time() - 1.0
+    recognition._speaking = True
+
+    assert recognition._should_advance_final_transcript_clock() is True
+
+
+def test_delayed_ignored_backchannel_is_consumed_without_reply_or_e2e_anchor() -> None:
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._agent = SimpleNamespace(stt=object())
+    activity._session = SimpleNamespace(
+        options=SimpleNamespace(
+            min_interruption_words=0,
+            interruption_ignore_words=["네", "예"],
+        ),
+        _closing=False,
+    )
+    activity._turn_detection = "vad"
+    activity._current_speech = None
+    activity._scheduling_paused = False
+    activity._preemptive_generation = None
+    activity._last_eou_timestamp = 123.0
+    activity._user_turn_completed_atask = None
+    activity._user_speech_started_during_interruptible_agent_speech = True
+    activity._dynamic_interruption = SimpleNamespace(
+        get_current_min_interruption_words=lambda: 0,
+    )
+
+    committed = activity.on_end_of_turn(
+        _EndOfTurnInfo(
+            skip_reply=False,
+            new_transcript="네",
+            transcript_confidence=1.0,
+            transcript_clock_suppressed=True,
+            started_speaking_at=None,
+            stopped_speaking_at=None,
+            transcription_delay=None,
+            end_of_turn_delay=None,
+        )
+    )
+
+    assert committed is True
+    assert activity._user_turn_completed_atask is None
+    assert activity._last_eou_timestamp is None
+    assert activity._user_speech_started_during_interruptible_agent_speech is False


### PR DESCRIPTION
## Summary
- Fix PROD-1419 by preventing stale user-audio timestamps from becoming response-latency anchors.
- Use VAD as a **candidate end-time signal**, not as the final latency anchor by itself.
- Confirm the candidate with STT transcript handling, then register it only after a reply-producing `speech_handle` is created.
- Bind response-latency anchors to the matching reply `speech_id`, so unrelated TTS metrics cannot consume an old user-stop timestamp.
- If transcript timing is unreliable, keep the user transcript and reply flow, but do not emit misleading EOU/e2e latency metrics for that turn.
- Preserve the existing ignore-words behavior only for non-suppressed real interruption cases.

## Root cause update

Audio + GCP verification changed the diagnosis. The affected calls are not simply "the user said a short acknowledgement during the greeting". The common failure mode is:

1. Agent greeting starts.
2. A short user-audio event is detected during the greeting. This can be noise, echo, a tiny blip, or an early utterance that should not yet become a response-latency anchor.
3. The old implementation stores that raw VAD end timestamp directly in `_last_eou_timestamp`.
4. A later real transcript or scripted/silence response reuses that stale timestamp.
5. `transcription_delay`, `end_of_turn_delay`, or raw `e2e_latency` includes the remaining agent greeting time and becomes inflated.

Observed examples, shown in KST:

| call | observation |
|--|--|
| `b24cc71a` | Agent greeting `14:06:19.629~14:06:30.015`; user-audio detection `14:06:21.304~14:06:21.333`; first response got `e2e=12865ms`. The audible `네` is after greeting. |
| `f8f02e9e` | Agent greeting `14:24:15.626~14:24:25.000`; user-audio detection `14:24:16.025~14:24:16.724`; first response got `e2e=12525ms`. The metric bug is early timestamp reuse. |
| `6b870ac6` | Agent greeting `08:42:19.980~08:42:25.376`; user-audio detection `08:42:20.571~08:42:20.821`; transcript `네.` arrived at `08:42:28.817`; `eou/transcription≈8125ms`, `e2e≈9637ms`. |
| preview `455e454b-f816-4730-a7ce-152df4790e2a` | Non-interruptible greeting had user-audio detection but no user message; a later silence/scripted response inherited `e2e≈19752ms`. |

## Design decision

The safe design is to combine VAD, STT, and reply ownership with different responsibilities:

- VAD gives a candidate timestamp: "the user may have stopped speaking here".
- STT transcript handling confirms whether this candidate belongs to a real user turn.
- A confirmed user turn still does not become an active response-latency anchor until a reply `speech_handle` is actually created.
- The active anchor is keyed by that reply `speech_id`; only the matching reply TTS metrics can consume it.
- If the STT transcript is too late to trust the VAD timestamp, or if the turn does not create a reply, we keep the conversation moving but drop the unreliable latency metric for that turn.

Scoring the two approaches after audio verification:

| approach | score | reason |
|--|--:|--|
| Treat late `네`/`예` as short acknowledgement and drop it by default | 4.5 / 10 | Can swallow a valid post-greeting answer. Does not fully cover transcript-less timestamp cases like preview `455...`. |
| Use VAD as a candidate and STT/reply ownership as confirmation | 8.5 / 10 | Matches the observed calls. Avoids wrong 10s+ latency while preserving the conversation flow. |

Tradeoff: when VAD/STT timing is unreliable or no reply is produced, this intentionally drops the EOU/e2e metric for that turn. That is preferable to persisting a known-wrong latency.

## Test plan

Latest patch:
- [x] `uv run pytest tests/test_prod1419_backchannel_latency.py -q` -> `16 passed`
- [x] `uv run ruff check livekit-agents/livekit/agents/voice/agent_activity.py tests/test_prod1419_backchannel_latency.py`
- [x] `git diff --check`

Regression coverage:
- raw VAD end does not directly create a response-latency anchor
- committed turns wait for reply generation before registering a response-latency anchor
- `skip_reply=True` turns do not leave a stale response-latency anchor
- non-interruptible no-reply turns do not leave a stale response-latency anchor
- response latency waits for matching reply `speech_id` TTS metrics and ignores unrelated TTS metrics
- suppressed transcript keeps the user answer and schedules the user-turn task without a latency anchor
- normal reply-producing turn registers reliable `stopped_speaking_at` to the matching reply speech
- non-suppressed delayed ignored acknowledgement is still handled by the existing ignore path
- suppressed transcript still updates the recency clock used by manual commit gating
- VAD start preserves interruption context even if STT/audio already interrupted the speech
- consumed delayed transcripts are preserved in chat history without creating a reply
- suppressed transcripts bypass min-word/ignore-word interruption filters and still commit
- suppressed turns do not emit misleading EOU metrics

Previous PR verification before the final stale-anchor adjustment:
- [x] `uv run ruff check --output-format=github .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/test_prod1419_backchannel_latency.py tests/test_audio_recognition_shutdown.py -q`
- [x] `python -m compileall -q livekit-agents/livekit/agents/voice/audio_recognition.py livekit-agents/livekit/agents/voice/agent_activity.py`