### PR TITLE
fix(ipc): bound shutdown chain unbounded awaits (regression #4580)

### DIFF
--- a/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/inference_proc_executor.py
@@ -14,6 +14,13 @@ from . import channel, proto
 from .inference_proc_lazy_main import ProcStartArgs, proc_main
 from .supervised_proc import SupervisedProc
 
+# Defense-in-depth hard timeout for an in-flight inference response.
+# Bounds `await fut` so a stuck inference proc cannot keep a parent-side
+# `_do_inference_task` alive forever, which would otherwise block
+# `_main_task`'s `cancel_and_wait` during shutdown.
+# See https://github.com/livekit/agents/issues/5497 and #3174.
+_INFERENCE_RESPONSE_TIMEOUT_S = 10.0
+
 
 class InferenceProcExecutor(SupervisedProc):
     def __init__(
@@ -94,7 +101,25 @@ class InferenceProcExecutor(SupervisedProc):
             self._active_requests.pop(request_id, None)
             raise
 
-        inf_resp = await fut
+        try:
+            inf_resp = await asyncio.wait_for(fut, timeout=_INFERENCE_RESPONSE_TIMEOUT_S)
+        except asyncio.TimeoutError as e:
+            logger.error(
+                "[ipc.inference_response_timeout] inference response timed out",
+                extra={
+                    "method": method,
+                    "request_id": request_id,
+                    "timeout_s": _INFERENCE_RESPONSE_TIMEOUT_S,
+                    **self.logging_extra(),
+                },
+            )
+            self._active_requests.pop(request_id, None)
+            if not fut.done():
+                fut.cancel()
+            raise RuntimeError(
+                f"inference of {method} timed out after {_INFERENCE_RESPONSE_TIMEOUT_S}s"
+            ) from e
+
         if inf_resp.error:
             raise RuntimeError(f"inference of {method} failed: {inf_resp.error}")
 

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -18,6 +18,13 @@ from .job_executor import JobStatus
 from .job_proc_lazy_main import ProcStartArgs, proc_main
 from .supervised_proc import SupervisedProc
 
+# Defense-in-depth hard timeout for the parent-side `_main_task` finally,
+# bounding `cancel_and_wait` over pending `_do_inference_task`s. Without
+# this, a single in-flight inference whose cancel does not propagate can
+# block `_supervise_task` cleanup and keep a K8s pod Terminating.
+# See https://github.com/livekit/agents/issues/5497 and #3174.
+_INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S = 10.0
+
 
 class ProcJobExecutor(SupervisedProc):
     def __init__(
@@ -119,7 +126,23 @@ class ProcJobExecutor(SupervisedProc):
                     self._inference_tasks.add(task)
                     task.add_done_callback(self._inference_tasks.discard)
         finally:
-            await aio.cancel_and_wait(*self._inference_tasks)
+            pending_tasks = tuple(self._inference_tasks)
+            if pending_tasks:
+                try:
+                    await asyncio.wait_for(
+                        aio.cancel_and_wait(*pending_tasks),
+                        timeout=_INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "[ipc.main_task_inference_cancel_timeout] inference tasks"
+                        " did not cancel in time, dropping",
+                        extra={
+                            "timeout_s": _INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S,
+                            "pending_count": len(pending_tasks),
+                            **self.logging_extra(),
+                        },
+                    )
 
     @log_exceptions(logger=logger)
     async def _supervise_task(self) -> None:

--- a/livekit-agents/livekit/agents/ipc/job_proc_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_executor.py
@@ -126,6 +126,8 @@ class ProcJobExecutor(SupervisedProc):
                     self._inference_tasks.add(task)
                     task.add_done_callback(self._inference_tasks.discard)
         finally:
+            # Snapshot the set so done-callbacks discarding entries during
+            # cancellation don't mutate what we're awaiting.
             pending_tasks = tuple(self._inference_tasks)
             if pending_tasks:
                 try:
@@ -134,12 +136,17 @@ class ProcJobExecutor(SupervisedProc):
                         timeout=_INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S,
                     )
                 except asyncio.TimeoutError:
+                    # cancel_and_wait may return before tasks finish if the
+                    # outer wait_for cancels mid-await; count what actually
+                    # leaked rather than the snapshot size.
+                    still_pending = sum(1 for t in pending_tasks if not t.done())
                     logger.error(
                         "[ipc.main_task_inference_cancel_timeout] inference tasks"
                         " did not cancel in time, dropping",
                         extra={
                             "timeout_s": _INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S,
-                            "pending_count": len(pending_tasks),
+                            "still_pending": still_pending,
+                            "snapshot_size": len(pending_tasks),
                             **self.logging_extra(),
                         },
                     )

--- a/livekit-agents/livekit/agents/ipc/job_thread_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_thread_executor.py
@@ -16,6 +16,23 @@ from ..utils.aio import duplex_unix
 from . import channel, job_proc_lazy_main, proto
 from .inference_executor import InferenceExecutor
 from .job_executor import JobStatus
+from .supervised_proc import (
+    _HELPERS_CANCEL_HARD_TIMEOUT_S,
+    _PCH_ACLOSE_HARD_TIMEOUT_S,
+    _SHUTDOWN_ACK_HARD_TIMEOUT_S,
+    _SHUTTING_DOWN_HARD_TIMEOUT_S,
+    _SUPERVISE_HARD_TIMEOUT_S,
+    _force_close_pch,
+)
+
+# Defense-in-depth hard timeout for the thread-side `_main_task` finally,
+# bounding `cancel_and_wait` over pending `_do_inference_task`s in the
+# thread executor. Mirrors the logic in `job_proc_executor.py`.
+_INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S = 10.0
+# Hard floor for thread join — the thread cannot be killed, so a stuck
+# `_join_fut` indicates a hung child. We still bound the parent-side
+# await so the worker isn't held hostage by a non-daemonic thread.
+_JOIN_FUT_HARD_TIMEOUT_S = 30.0
 
 
 @dataclass
@@ -213,25 +230,60 @@ class ThreadJobExecutor:
         with contextlib.suppress(utils.aio.duplex_unix.DuplexClosed):
             await channel.asend_message(self._pch, proto.ShutdownRequest())
 
+        shutdown_ack_timeout = min(self._opts.close_timeout, _SHUTDOWN_ACK_HARD_TIMEOUT_S)
         try:
-            await asyncio.wait_for(self._shutdown_ack_fut, timeout=self._opts.close_timeout)
+            await asyncio.wait_for(self._shutdown_ack_fut, timeout=shutdown_ack_timeout)
         except asyncio.TimeoutError:
-            logger.error("job did not ack shutdown in time", extra=self.logging_extra())
+            logger.error(
+                "[thread.shutdown_ack_timeout] job did not ack shutdown in time",
+                extra={"timeout_s": shutdown_ack_timeout, **self.logging_extra()},
+            )
 
         if not self._shutting_down_fut.done():
-            await self._shutting_down_fut
-
-        try:
-            if self._main_atask:
+            try:
                 await asyncio.wait_for(
-                    asyncio.shield(self._main_atask), timeout=self._opts.close_timeout
+                    asyncio.shield(self._shutting_down_fut),
+                    timeout=_SHUTTING_DOWN_HARD_TIMEOUT_S,
                 )
-        except asyncio.TimeoutError:
-            logger.error("job shutdown is taking too much time..", extra=self.logging_extra())
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[thread.shutting_down_timeout] waiting for ShuttingDown timed"
+                    " out (thread cannot be killed)",
+                    extra={
+                        "timeout_s": _SHUTTING_DOWN_HARD_TIMEOUT_S,
+                        **self.logging_extra(),
+                    },
+                )
+
+        if self._main_atask is not None and not self._main_atask.done():
+            main_first_timeout = min(self._opts.close_timeout, _SUPERVISE_HARD_TIMEOUT_S)
+            try:
+                await asyncio.wait_for(asyncio.shield(self._main_atask), timeout=main_first_timeout)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[thread.main_first_timeout] job shutdown is taking too much time..",
+                    extra={
+                        "timeout_s": main_first_timeout,
+                        **self.logging_extra(),
+                    },
+                )
 
         async with self._lock:
-            if self._main_atask:
-                await asyncio.shield(self._main_atask)
+            if self._main_atask is not None and not self._main_atask.done():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(self._main_atask),
+                        timeout=_SUPERVISE_HARD_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "[thread.main_lock_timeout] main task did not complete"
+                        " after kill attempt, dropping",
+                        extra={
+                            "timeout_s": _SUPERVISE_HARD_TIMEOUT_S,
+                            **self.logging_extra(),
+                        },
+                    )
 
     async def _do_inference_task(self, inf_req: proto.InferenceRequest) -> None:
         if self._inference_executor is None:
@@ -283,12 +335,70 @@ class ThreadJobExecutor:
         ping_task = asyncio.create_task(self._ping_task())
         monitor_task = asyncio.create_task(self._monitor_task())
 
-        await self._join_fut
-        await utils.aio.cancel_and_wait(ping_task, monitor_task)
-        await utils.aio.cancel_and_wait(*self._inference_tasks)
+        # Thread cannot be killed; if `_join_fut` never resolves the
+        # underlying thread is hung. We still bound the wait so the
+        # async surface doesn't block the worker forever — the thread
+        # leaks as a documented worst case (callers should
+        # log/escalate).
+        try:
+            await asyncio.wait_for(asyncio.shield(self._join_fut), timeout=_JOIN_FUT_HARD_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            logger.error(
+                "[thread.join_timeout] thread did not finish in time; thread"
+                " leaks until process exit",
+                extra={"timeout_s": _JOIN_FUT_HARD_TIMEOUT_S, **self.logging_extra()},
+            )
+
+        helper_tasks = (ping_task, monitor_task)
+        try:
+            await asyncio.wait_for(
+                utils.aio.cancel_and_wait(*helper_tasks),
+                timeout=_HELPERS_CANCEL_HARD_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            still_pending = sum(1 for t in helper_tasks if not t.done())
+            logger.error(
+                "[thread.helpers_cancel_timeout] helper tasks did not cancel in time, dropping",
+                extra={
+                    "timeout_s": _HELPERS_CANCEL_HARD_TIMEOUT_S,
+                    "still_pending": still_pending,
+                    **self.logging_extra(),
+                },
+            )
+
+        pending_inference = tuple(self._inference_tasks)
+        if pending_inference:
+            try:
+                await asyncio.wait_for(
+                    utils.aio.cancel_and_wait(*pending_inference),
+                    timeout=_INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                still_pending = sum(1 for t in pending_inference if not t.done())
+                logger.error(
+                    "[thread.inference_cancel_timeout] inference tasks did not"
+                    " cancel in time, dropping",
+                    extra={
+                        "timeout_s": _INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S,
+                        "still_pending": still_pending,
+                        "snapshot_size": len(pending_inference),
+                        **self.logging_extra(),
+                    },
+                )
 
         with contextlib.suppress(duplex_unix.DuplexClosed):
-            await self._pch.aclose()
+            try:
+                await asyncio.wait_for(self._pch.aclose(), timeout=_PCH_ACLOSE_HARD_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[thread.pch_aclose_timeout] pch.aclose timed out,"
+                    " force-closing transport and socket",
+                    extra={
+                        "timeout_s": _PCH_ACLOSE_HARD_TIMEOUT_S,
+                        **self.logging_extra(),
+                    },
+                )
+                _force_close_pch(self._pch)
 
         self._job_status = JobStatus.SUCCESS
 

--- a/livekit-agents/livekit/agents/ipc/job_thread_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_thread_executor.py
@@ -21,6 +21,7 @@ from .supervised_proc import (
     _PCH_ACLOSE_HARD_TIMEOUT_S,
     _SHUTDOWN_ACK_HARD_TIMEOUT_S,
     _SHUTTING_DOWN_HARD_TIMEOUT_S,
+    _START_CLEANUP_PCH_ACLOSE_HARD_TIMEOUT_S,
     _SUPERVISE_HARD_TIMEOUT_S,
     _force_close_pch,
 )
@@ -29,10 +30,14 @@ from .supervised_proc import (
 # bounding `cancel_and_wait` over pending `_do_inference_task`s in the
 # thread executor. Mirrors the logic in `job_proc_executor.py`.
 _INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S = 10.0
-# Hard floor for thread join — the thread cannot be killed, so a stuck
-# `_join_fut` indicates a hung child. We still bound the parent-side
-# await so the worker isn't held hostage by a non-daemonic thread.
-_JOIN_FUT_HARD_TIMEOUT_S = 30.0
+# NOTE: the `_join_fut` wait inside `_main_task` is intentionally unbounded.
+# Threads cannot be killed, and `_join_fut` resolves on **normal job
+# termination** as well as shutdown. Bounding it here would cause the
+# normal long-running job path (typical voice agent calls run for minutes)
+# to fall through and mark `JobStatus.SUCCESS` while the worker thread is
+# still alive. The async surface is kept bounded in `aclose()` via the
+# `_main_atask` shielded wait (`_SUPERVISE_HARD_TIMEOUT_S`); a hung thread
+# is a documented worst-case leak that callers should log/escalate.
 
 
 @dataclass
@@ -169,7 +174,22 @@ class ThreadJobExecutor:
 
                 if pch is not None:
                     with contextlib.suppress(duplex_unix.DuplexClosed):
-                        await pch.aclose()
+                        try:
+                            await asyncio.wait_for(
+                                pch.aclose(),
+                                timeout=_START_CLEANUP_PCH_ACLOSE_HARD_TIMEOUT_S,
+                            )
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                "[thread.start_cleanup_pch_aclose_timeout]"
+                                " pch.aclose timed out during _start exception"
+                                " cleanup, aborting transport and closing socket",
+                                extra={
+                                    "timeout_s": _START_CLEANUP_PCH_ACLOSE_HARD_TIMEOUT_S,
+                                    **self.logging_extra(),
+                                },
+                            )
+                            _force_close_pch(pch)
                 else:
                     with contextlib.suppress(OSError):
                         mp_pch.close()
@@ -232,7 +252,13 @@ class ThreadJobExecutor:
 
         shutdown_ack_timeout = min(self._opts.close_timeout, _SHUTDOWN_ACK_HARD_TIMEOUT_S)
         try:
-            await asyncio.wait_for(self._shutdown_ack_fut, timeout=shutdown_ack_timeout)
+            # Shield so a timeout cancels only this wait, not the underlying
+            # future itself. A subsequent aclose() (pool double-close,
+            # launch-failure cleanup) must observe the same future state
+            # instead of getting an immediate CancelledError.
+            await asyncio.wait_for(
+                asyncio.shield(self._shutdown_ack_fut), timeout=shutdown_ack_timeout
+            )
         except asyncio.TimeoutError:
             logger.error(
                 "[thread.shutdown_ack_timeout] job did not ack shutdown in time",
@@ -335,19 +361,14 @@ class ThreadJobExecutor:
         ping_task = asyncio.create_task(self._ping_task())
         monitor_task = asyncio.create_task(self._monitor_task())
 
-        # Thread cannot be killed; if `_join_fut` never resolves the
-        # underlying thread is hung. We still bound the wait so the
-        # async surface doesn't block the worker forever — the thread
-        # leaks as a documented worst case (callers should
-        # log/escalate).
-        try:
-            await asyncio.wait_for(asyncio.shield(self._join_fut), timeout=_JOIN_FUT_HARD_TIMEOUT_S)
-        except asyncio.TimeoutError:
-            logger.error(
-                "[thread.join_timeout] thread did not finish in time; thread"
-                " leaks until process exit",
-                extra={"timeout_s": _JOIN_FUT_HARD_TIMEOUT_S, **self.logging_extra()},
-            )
+        # Wait for the thread to terminate. This is intentionally unbounded:
+        # `_join_fut` fires on normal job end as well as on shutdown, so a
+        # bound here would also clip happy-path long-running jobs (see the
+        # module-level comment on `_JOIN_FUT_HARD_TIMEOUT_S` removal). The
+        # async surface stays bounded in `aclose()` via the shielded
+        # `_main_atask` wait — a thread that ignores shutdown leaks until
+        # process exit but does not block the worker loop.
+        await self._join_fut
 
         helper_tasks = (ping_task, monitor_task)
         try:

--- a/livekit-agents/livekit/agents/ipc/proc_pool.py
+++ b/livekit-agents/livekit/agents/ipc/proc_pool.py
@@ -255,6 +255,14 @@ class ProcPool(utils.EventEmitter[EventTypes]):
                 await asyncio.sleep(0.1)
         except asyncio.CancelledError:
             await aio.cancel_and_wait(*self._spawn_tasks)
+            # `proc.aclose()` has a bounded shutdown chain in SupervisedProc,
+            # but its internal `_supervise_atask` may legitimately outlive
+            # `aclose()` if a hard timeout fires. The monitor tasks below
+            # `await proc.join()`, which awaits that same `_supervise_atask`
+            # — so without an explicit cancel here, the pool would re-hang
+            # via the monitor even though aclose() returned. Cancel them
+            # so the pool can finish closing.
             await asyncio.gather(*[proc.aclose() for proc in self._executors])
             await asyncio.gather(*self._close_tasks)
-            await asyncio.gather(*self._monitor_tasks)
+            if self._monitor_tasks:
+                await aio.cancel_and_wait(*self._monitor_tasks)

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -27,22 +27,52 @@ from . import channel, proto
 from .log_queue import LogQueueListener
 
 # Defense-in-depth hard timeouts for the parent-side shutdown chain.
-# These bound four awaits that are otherwise unbounded (or effectively
-# unbounded because they pivot on `close_timeout`, which can be set to
-# very large values for K8s graceful shutdown). Without these bounds a
-# stuck IPC channel or a stuck `_supervise_task` cleanup step can keep
-# a pod Terminating until the K8s grace period expires.
+# These bound six awaits in this module that are otherwise unbounded
+# (or effectively unbounded because they pivot on `close_timeout`,
+# which K8s operators set to large values for graceful shutdown).
+# Without these bounds a stuck IPC channel or a stuck `_supervise_task`
+# cleanup step can keep a pod Terminating until the K8s grace period
+# expires.
+#
+# Rationale for values: K8s typically uses terminationGracePeriodSeconds
+# in the 30s..18000s range. The longest hard floor here (10s) is well
+# below all common grace periods, so it never gates the happy path, but
+# it ensures every site escapes within 10s of the trigger.
+#
 # See https://github.com/livekit/agents/issues/5497,
 # https://github.com/livekit/agents/issues/3174,
 # https://github.com/livekit/agents/pull/4580 (regression source),
 # https://github.com/livekit/agents/pull/5602 (child-side complement).
+_SHUTDOWN_ACK_HARD_TIMEOUT_S = 10.0
 _SHUTTING_DOWN_HARD_TIMEOUT_S = 10.0
 _SUPERVISE_HARD_TIMEOUT_S = 10.0
 _HELPERS_CANCEL_HARD_TIMEOUT_S = 10.0
 _PCH_ACLOSE_HARD_TIMEOUT_S = 5.0
+_KILL_SUPERVISE_HARD_TIMEOUT_S = 10.0
+_START_CLEANUP_PCH_ACLOSE_HARD_TIMEOUT_S = 5.0
 
 _mask_ctrl_c_refcount = 0
 _mask_ctrl_c_original: Callable[[int, FrameType | None], Any] | int | None = signal.SIG_DFL
+
+
+def _force_close_pch(pch: duplex_unix._AsyncDuplex) -> None:
+    """Best-effort socket/transport cleanup after `pch.aclose()` times out.
+
+    `duplex_unix._AsyncDuplex.aclose()` does `writer.close() -> wait_closed()
+    -> sock.close()`. When `asyncio.wait_for` cancels at `wait_closed()`,
+    the final `_sock.close()` is skipped, leaking the fd until process
+    exit. Mirror what `aclose()` would have done so the fd is released
+    promptly even on a stuck shutdown.
+    """
+    try:
+        transport = pch._writer.transport
+    except AttributeError:
+        transport = None
+    if transport is not None:
+        with contextlib.suppress(Exception):
+            transport.abort()
+    with contextlib.suppress(Exception):
+        pch._sock.close()
 
 
 @contextlib.contextmanager
@@ -199,7 +229,22 @@ class SupervisedProc(ABC):
 
                 if pch is not None:
                     with contextlib.suppress(duplex_unix.DuplexClosed):
-                        await pch.aclose()
+                        try:
+                            await asyncio.wait_for(
+                                pch.aclose(),
+                                timeout=_START_CLEANUP_PCH_ACLOSE_HARD_TIMEOUT_S,
+                            )
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                "[ipc.start_cleanup_pch_aclose_timeout] pch.aclose"
+                                " timed out during _start exception cleanup,"
+                                " aborting transport and closing sockets",
+                                extra={
+                                    "timeout_s": _START_CLEANUP_PCH_ACLOSE_HARD_TIMEOUT_S,
+                                    **self.logging_extra(),
+                                },
+                            )
+                            _force_close_pch(pch)
 
                 if log_listener is not None:
                     with contextlib.suppress(duplex_unix.DuplexClosed):
@@ -290,12 +335,19 @@ class SupervisedProc(ABC):
         with contextlib.suppress(duplex_unix.DuplexClosed):
             await channel.asend_message(self._pch, proto.ShutdownRequest())
 
+        # Use min(close_timeout, hard_floor) so a large operator-configured
+        # close_timeout (e.g. K8s grace period of hours) cannot stretch the
+        # worst-case aclose() chain into the 10h range.
+        shutdown_ack_timeout = min(self._opts.close_timeout, _SHUTDOWN_ACK_HARD_TIMEOUT_S)
         try:
-            await asyncio.wait_for(self._shutdown_ack_fut, timeout=self._opts.close_timeout)
+            await asyncio.wait_for(self._shutdown_ack_fut, timeout=shutdown_ack_timeout)
         except asyncio.TimeoutError:
             logger.error(
-                "process did not ack shutdown in time, killing process",
-                extra=self.logging_extra(),
+                "[ipc.shutdown_ack_timeout] process did not ack shutdown in time, killing process",
+                extra={
+                    "timeout_s": shutdown_ack_timeout,
+                    **self.logging_extra(),
+                },
             )
             await self._send_dump_signal()
             await self._send_kill_signal()
@@ -319,14 +371,21 @@ class SupervisedProc(ABC):
                 await self._send_kill_signal()
 
         if self._supervise_atask and not self._supervise_atask.done():
+            # Same min(close_timeout, hard_floor) rationale as
+            # shutdown_ack above; bound the chain regardless of operator
+            # config.
+            supervise_first_timeout = min(self._opts.close_timeout, _SUPERVISE_HARD_TIMEOUT_S)
             try:
                 await asyncio.wait_for(
-                    asyncio.shield(self._supervise_atask), timeout=self._opts.close_timeout
+                    asyncio.shield(self._supervise_atask), timeout=supervise_first_timeout
                 )
             except asyncio.TimeoutError:
                 logger.error(
-                    "process did not exit in time, killing process",
-                    extra=self.logging_extra(),
+                    "[ipc.supervise_first_timeout] process did not exit in time, killing process",
+                    extra={
+                        "timeout_s": supervise_first_timeout,
+                        **self.logging_extra(),
+                    },
                 )
                 await self._send_dump_signal()
                 await self._send_kill_signal()
@@ -358,8 +417,21 @@ class SupervisedProc(ABC):
         await self._send_kill_signal()
 
         async with self._lock:
-            if self._supervise_atask:
-                await asyncio.shield(self._supervise_atask)
+            if self._supervise_atask and not self._supervise_atask.done():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(self._supervise_atask),
+                        timeout=_KILL_SUPERVISE_HARD_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "[ipc.kill_supervise_timeout] supervise task did not"
+                        " complete after kill, dropping",
+                        extra={
+                            "timeout_s": _KILL_SUPERVISE_HARD_TIMEOUT_S,
+                            **self.logging_extra(),
+                        },
+                    )
 
     async def _send_dump_signal(self) -> None:
         if not self.enabled_stack_trace_dump:
@@ -436,17 +508,26 @@ class SupervisedProc(ABC):
         await self._join_fut
         self._exitcode = self._proc.exitcode
         self._proc.close()
+        helper_tasks = (ping_task, read_ipc_task, main_task)
         try:
             await asyncio.wait_for(
-                aio.cancel_and_wait(ping_task, read_ipc_task, main_task),
+                aio.cancel_and_wait(*helper_tasks),
                 timeout=_HELPERS_CANCEL_HARD_TIMEOUT_S,
             )
         except asyncio.TimeoutError:
+            # cancel_and_wait issues `.cancel()` first and then awaits the
+            # waiters; when wait_for cancels the outer awaitable the inner
+            # tasks have been *requested* to cancel but may not have
+            # finished. Count and log the leftover, then continue —
+            # downstream cleanup (process exited, sockets closed) limits
+            # the blast radius.
+            still_pending = sum(1 for t in helper_tasks if not t.done())
             logger.error(
                 "[ipc.helpers_cancel_timeout] supervised helper tasks did not"
                 " cancel in time, dropping",
                 extra={
                     "timeout_s": _HELPERS_CANCEL_HARD_TIMEOUT_S,
+                    "still_pending": still_pending,
                     **self.logging_extra(),
                 },
             )
@@ -459,10 +540,11 @@ class SupervisedProc(ABC):
                 )
             except asyncio.TimeoutError:
                 logger.error(
-                    "[ipc.helpers_cancel_timeout] memory monitor task did not"
-                    " cancel in time, dropping",
+                    "[ipc.memory_monitor_cancel_timeout] memory monitor task did"
+                    " not cancel in time, dropping",
                     extra={
                         "timeout_s": _HELPERS_CANCEL_HARD_TIMEOUT_S,
+                        "still_pending": int(not memory_monitor_task.done()),
                         **self.logging_extra(),
                     },
                 )
@@ -471,13 +553,19 @@ class SupervisedProc(ABC):
             try:
                 await asyncio.wait_for(self._pch.aclose(), timeout=_PCH_ACLOSE_HARD_TIMEOUT_S)
             except asyncio.TimeoutError:
-                logger.warning(
-                    "[ipc.pch_aclose_timeout] supervised pch.aclose timed out, dropping",
+                # `_AsyncDuplex.aclose()` is `writer.close() -> wait_closed()
+                # -> sock.close()`. Outer cancel at `wait_closed()` skips
+                # `sock.close()`, leaking the fd. Force-close so the fd
+                # is released even on a stuck shutdown.
+                logger.error(
+                    "[ipc.pch_aclose_timeout] supervised pch.aclose timed out,"
+                    " force-closing transport and socket",
                     extra={
                         "timeout_s": _PCH_ACLOSE_HARD_TIMEOUT_S,
                         **self.logging_extra(),
                     },
                 )
+                _force_close_pch(self._pch)
 
         if self._exitcode != 0 and not self._kill_sent:
             logger.error(

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -26,6 +26,21 @@ from ..utils.aio import duplex_unix
 from . import channel, proto
 from .log_queue import LogQueueListener
 
+# Defense-in-depth hard timeouts for the parent-side shutdown chain.
+# These bound four awaits that are otherwise unbounded (or effectively
+# unbounded because they pivot on `close_timeout`, which can be set to
+# very large values for K8s graceful shutdown). Without these bounds a
+# stuck IPC channel or a stuck `_supervise_task` cleanup step can keep
+# a pod Terminating until the K8s grace period expires.
+# See https://github.com/livekit/agents/issues/5497,
+# https://github.com/livekit/agents/issues/3174,
+# https://github.com/livekit/agents/pull/4580 (regression source),
+# https://github.com/livekit/agents/pull/5602 (child-side complement).
+_SHUTTING_DOWN_HARD_TIMEOUT_S = 10.0
+_SUPERVISE_HARD_TIMEOUT_S = 10.0
+_HELPERS_CANCEL_HARD_TIMEOUT_S = 10.0
+_PCH_ACLOSE_HARD_TIMEOUT_S = 5.0
+
 _mask_ctrl_c_refcount = 0
 _mask_ctrl_c_original: Callable[[int, FrameType | None], Any] | int | None = signal.SIG_DFL
 
@@ -286,7 +301,22 @@ class SupervisedProc(ABC):
             await self._send_kill_signal()
 
         if not self._shutting_down_fut.done():
-            await self._shutting_down_fut
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(self._shutting_down_fut),
+                    timeout=_SHUTTING_DOWN_HARD_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[ipc.shutting_down_timeout] waiting for ShuttingDown timed out,"
+                    " killing process",
+                    extra={
+                        "timeout_s": _SHUTTING_DOWN_HARD_TIMEOUT_S,
+                        **self.logging_extra(),
+                    },
+                )
+                await self._send_dump_signal()
+                await self._send_kill_signal()
 
         if self._supervise_atask and not self._supervise_atask.done():
             try:
@@ -302,8 +332,21 @@ class SupervisedProc(ABC):
                 await self._send_kill_signal()
 
         async with self._lock:
-            if self._supervise_atask:
-                await asyncio.shield(self._supervise_atask)
+            if self._supervise_atask and not self._supervise_atask.done():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(self._supervise_atask),
+                        timeout=_SUPERVISE_HARD_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "[ipc.supervise_atask_timeout] supervise task did not"
+                        " complete after kill, dropping",
+                        extra={
+                            "timeout_s": _SUPERVISE_HARD_TIMEOUT_S,
+                            **self.logging_extra(),
+                        },
+                    )
 
     async def kill(self) -> None:
         """forcefully kill the supervised process"""
@@ -393,13 +436,48 @@ class SupervisedProc(ABC):
         await self._join_fut
         self._exitcode = self._proc.exitcode
         self._proc.close()
-        await aio.cancel_and_wait(ping_task, read_ipc_task, main_task)
+        try:
+            await asyncio.wait_for(
+                aio.cancel_and_wait(ping_task, read_ipc_task, main_task),
+                timeout=_HELPERS_CANCEL_HARD_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "[ipc.helpers_cancel_timeout] supervised helper tasks did not"
+                " cancel in time, dropping",
+                extra={
+                    "timeout_s": _HELPERS_CANCEL_HARD_TIMEOUT_S,
+                    **self.logging_extra(),
+                },
+            )
 
         if memory_monitor_task is not None:
-            await aio.cancel_and_wait(memory_monitor_task)
+            try:
+                await asyncio.wait_for(
+                    aio.cancel_and_wait(memory_monitor_task),
+                    timeout=_HELPERS_CANCEL_HARD_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[ipc.helpers_cancel_timeout] memory monitor task did not"
+                    " cancel in time, dropping",
+                    extra={
+                        "timeout_s": _HELPERS_CANCEL_HARD_TIMEOUT_S,
+                        **self.logging_extra(),
+                    },
+                )
 
         with contextlib.suppress(duplex_unix.DuplexClosed):
-            await self._pch.aclose()
+            try:
+                await asyncio.wait_for(self._pch.aclose(), timeout=_PCH_ACLOSE_HARD_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[ipc.pch_aclose_timeout] supervised pch.aclose timed out, dropping",
+                    extra={
+                        "timeout_s": _PCH_ACLOSE_HARD_TIMEOUT_S,
+                        **self.logging_extra(),
+                    },
+                )
 
         if self._exitcode != 0 and not self._kill_sent:
             logger.error(

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -340,7 +340,13 @@ class SupervisedProc(ABC):
         # worst-case aclose() chain into the 10h range.
         shutdown_ack_timeout = min(self._opts.close_timeout, _SHUTDOWN_ACK_HARD_TIMEOUT_S)
         try:
-            await asyncio.wait_for(self._shutdown_ack_fut, timeout=shutdown_ack_timeout)
+            # Shield so a timeout cancels only this wait, not the underlying
+            # future itself. A subsequent aclose() (pool double-close,
+            # launch-failure cleanup) must observe the same future state
+            # instead of getting an immediate CancelledError.
+            await asyncio.wait_for(
+                asyncio.shield(self._shutdown_ack_fut), timeout=shutdown_ack_timeout
+            )
         except asyncio.TimeoutError:
             logger.error(
                 "[ipc.shutdown_ack_timeout] process did not ack shutdown in time, killing process",

--- a/tests/test_ipc_shutdown_timeouts.py
+++ b/tests/test_ipc_shutdown_timeouts.py
@@ -15,6 +15,7 @@ See:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import multiprocessing as mp
 import socket
 from unittest.mock import AsyncMock, MagicMock
@@ -24,12 +25,16 @@ import pytest
 from livekit.agents.ipc import (
     inference_proc_executor,
     job_proc_executor,
+    job_thread_executor,
     proto,
     supervised_proc,
 )
 from livekit.agents.ipc.inference_proc_executor import InferenceProcExecutor
+from livekit.agents.ipc.job_executor import JobStatus
+from livekit.agents.ipc.job_thread_executor import ThreadJobExecutor
 from livekit.agents.ipc.supervised_proc import SupervisedProc
 from livekit.agents.utils import aio
+from livekit.agents.utils.aio import duplex_unix
 
 
 class _DummySupervisedProc(SupervisedProc):
@@ -292,38 +297,303 @@ async def test_main_task_inference_cancel_timeout_bounds(monkeypatch):
 
 
 async def test_pch_aclose_timeout_force_closes_sock(monkeypatch):
-    """When pch.aclose() hangs, the timeout branch must force-close
-    the underlying transport + socket to release the fd promptly.
+    """When `_supervise_task()` reaches its tail-end `pch.aclose()` and
+    that aclose hangs, the production path must time out within
+    `_PCH_ACLOSE_HARD_TIMEOUT_S` and invoke `_force_close_pch` so the fd
+    is released.
+
+    Drives the real `SupervisedProc._supervise_task()` body — not a
+    reimplementation of the wait_for+force_close pattern — so a future
+    edit that drops the wrap or moves the call site will break this test
+    instead of silently passing.
     """
 
     monkeypatch.setattr(supervised_proc, "_PCH_ACLOSE_HARD_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(supervised_proc, "_HELPERS_CANCEL_HARD_TIMEOUT_S", 0.05)
 
     force_close_called: list[object] = []
+    monkeypatch.setattr(
+        supervised_proc, "_force_close_pch", lambda pch: force_close_called.append(pch)
+    )
 
-    def _capture_force_close(pch):
-        force_close_called.append(pch)
+    proc = _make_dummy_supervised()
 
-    monkeypatch.setattr(supervised_proc, "_force_close_pch", _capture_force_close)
+    # Short-circuit the helper tasks that `_supervise_task` spawns so it
+    # reaches the pch.aclose tail without spinning forever.
+    async def _noop_main(ipc_ch: aio.ChanReceiver[object]) -> None:
+        return None
 
-    # Direct call into the helper path: run the body that wraps pch.aclose
-    # via a minimal harness. Use a hanging coroutine to emulate aclose
-    # never resolving.
-    import contextlib
+    async def _noop_read(ipc_ch: aio.Chan[object], pong_timeout: aio.Sleep) -> None:
+        return None
 
-    async def _hang() -> None:
+    async def _noop_ping(pong_timeout: aio.Sleep) -> None:
+        return None
+
+    monkeypatch.setattr(proc, "_main_task", _noop_main)
+    monkeypatch.setattr(proc, "_read_ipc_task", _noop_read)
+    monkeypatch.setattr(proc, "_ping_pong_task", _noop_ping)
+
+    # Pre-resolve `_initialize_fut` and `_join_fut` so `_supervise_task`
+    # walks past them straight into the cleanup phase.
+    proc._initialize_fut.set_result(None)
+    proc._join_fut = asyncio.Future[None]()
+    proc._join_fut.set_result(None)
+
+    fake_proc = MagicMock()
+    fake_proc.exitcode = 0
+    fake_proc.close = MagicMock()
+    proc._proc = fake_proc
+
+    # `_pch.aclose` hangs — this is the regression site the wrap is
+    # supposed to defend.
+    fake_pch = MagicMock(spec=duplex_unix._AsyncDuplex)
+
+    async def _hang_aclose() -> None:
         await asyncio.sleep(60)
 
-    fake_pch = MagicMock()
-    fake_pch.aclose = _hang
+    fake_pch.aclose = _hang_aclose
+    proc._pch = fake_pch
 
-    with contextlib.suppress(asyncio.TimeoutError):
-        try:
-            await asyncio.wait_for(
-                fake_pch.aclose(),
-                timeout=supervised_proc._PCH_ACLOSE_HARD_TIMEOUT_S,
-            )
-        except asyncio.TimeoutError:
-            supervised_proc._force_close_pch(fake_pch)
-            raise
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    await proc._supervise_task()
+    elapsed = loop.time() - started
 
-    assert force_close_called == [fake_pch]
+    assert force_close_called == [fake_pch], (
+        f"_force_close_pch not invoked via production path: {force_close_called!r}"
+    )
+    # Bounded by HELPERS_CANCEL + PCH_ACLOSE timeouts (both 0.05s); generous
+    # slack for CI scheduling.
+    assert elapsed < 2.0, f"_supervise_task did not bound pch.aclose: {elapsed:.3f}s"
+
+
+async def test_thread_main_task_does_not_false_success_while_thread_runs(monkeypatch):
+    """Regression guard for `_main_task`'s `_join_fut` wait.
+
+    The PR's first attempt bounded the wait with `_JOIN_FUT_HARD_TIMEOUT_S`
+    (30s) and unconditionally set `JobStatus.SUCCESS` on fall-through.
+    That falsely reported normal long-running calls (typical voice agents
+    run for minutes) as SUCCESS while the underlying thread was still
+    alive. The wait must stay unbounded; bounding lives in `aclose()` via
+    the shielded `_main_atask`.
+    """
+
+    loop = asyncio.get_running_loop()
+    executor = ThreadJobExecutor(
+        initialize_process_fnc=lambda _: None,
+        job_entrypoint_fnc=lambda _: asyncio.sleep(0),
+        session_end_fnc=None,
+        inference_executor=None,
+        initialize_timeout=1.0,
+        close_timeout=1.0,
+        session_end_timeout=1.0,
+        ping_interval=10.0,
+        high_ping_threshold=10.0,
+        http_proxy=None,
+        loop=loop,
+    )
+
+    # Short-circuit ping/monitor helpers that `_main_task` spawns —
+    # otherwise they'd try to read from a non-existent `_pch`.
+    async def _noop_ping() -> None:
+        await asyncio.sleep(60)
+
+    async def _noop_monitor() -> None:
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr(executor, "_ping_task", _noop_ping)
+    monkeypatch.setattr(executor, "_monitor_task", _noop_monitor)
+
+    executor._pch = AsyncMock()
+    executor._initialize_fut.set_result(None)
+    executor._join_fut = asyncio.Future[None]()  # unresolved — thread "still running"
+
+    main_task = asyncio.create_task(executor._main_task())
+
+    # Wait longer than the old `_JOIN_FUT_HARD_TIMEOUT_S=30.0`s would have
+    # been monkeypatched to (had it survived). 0.2s is plenty of real wall
+    # clock to expose a still-bounded wait misfiring.
+    await asyncio.sleep(0.2)
+
+    try:
+        assert not main_task.done(), (
+            "regression: _main_task returned while _join_fut still pending"
+            " — bounded wait re-introduced on the normal path"
+        )
+        assert executor._job_status is None, (
+            f"regression: _job_status set to {executor._job_status!r} while"
+            " thread is still running — false SUCCESS emission"
+        )
+
+        # Resolving the join future should now let _main_task complete
+        # cleanly with SUCCESS, proving the wait was the only blocker.
+        executor._join_fut.set_result(None)
+        await asyncio.wait_for(main_task, timeout=2.0)
+        assert executor._job_status == JobStatus.SUCCESS, (
+            f"_main_task did not converge to SUCCESS after join: {executor._job_status!r}"
+        )
+    finally:
+        if not main_task.done():
+            main_task.cancel()
+            with contextlib.suppress(BaseException):
+                await main_task
+
+
+async def test_supervised_aclose_idempotent_under_ack_timeout(monkeypatch):
+    """Repeated `SupervisedProc.aclose()` after a first ack timeout must
+    not raise `CancelledError`.
+
+    Before the shield fix, `wait_for(self._shutdown_ack_fut, ...)` would
+    cancel `_shutdown_ack_fut` on timeout. The next aclose() call (pool
+    double-close, launch-failure cleanup) would then re-await the cancelled
+    future and immediately raise `CancelledError`, breaking idempotency.
+    """
+
+    monkeypatch.setattr(supervised_proc, "_SHUTDOWN_ACK_HARD_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(supervised_proc, "_SHUTTING_DOWN_HARD_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(supervised_proc, "_SUPERVISE_HARD_TIMEOUT_S", 0.05)
+
+    proc = _make_dummy_supervised()
+    proc._pch = AsyncMock()
+    proc._pch.aclose = AsyncMock()
+
+    async def _noop() -> None:
+        return None
+
+    proc._supervise_atask = asyncio.create_task(_noop())
+    monkeypatch.setattr(proc, "_send_dump_signal", _noop)
+    monkeypatch.setattr(proc, "_send_kill_signal", _noop)
+
+    # First aclose: shutdown_ack times out → escalates to dump+kill.
+    await proc.aclose()
+
+    # The shield must keep `_shutdown_ack_fut` pending across the timeout.
+    assert not proc._shutdown_ack_fut.cancelled(), (
+        "shield missing: first aclose() cancelled _shutdown_ack_fut"
+    )
+    assert not proc._shutdown_ack_fut.done(), (
+        "unexpected: _shutdown_ack_fut resolved by something other than producer"
+    )
+
+    # Second aclose: must not raise CancelledError. (Re-arm supervise_atask
+    # so the path is fully re-entered; the supervise wait is already
+    # shielded so it's not the regression target here.)
+    proc._supervise_atask = asyncio.create_task(_noop())
+    try:
+        await proc.aclose()
+    except asyncio.CancelledError as exc:  # pragma: no cover — regression
+        pytest.fail(f"second aclose() raised CancelledError (shield regression): {exc!r}")
+
+
+async def test_thread_aclose_idempotent_under_ack_timeout(monkeypatch):
+    """ThreadJobExecutor mirror of `test_supervised_aclose_idempotent_under_ack_timeout`.
+
+    The same shield-on-`_shutdown_ack_fut` invariant must hold for the
+    threaded executor; both call sites had identical unshielded `wait_for`.
+    """
+
+    monkeypatch.setattr(supervised_proc, "_SHUTDOWN_ACK_HARD_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(supervised_proc, "_SHUTTING_DOWN_HARD_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(supervised_proc, "_SUPERVISE_HARD_TIMEOUT_S", 0.05)
+
+    loop = asyncio.get_running_loop()
+    executor = ThreadJobExecutor(
+        initialize_process_fnc=lambda _: None,
+        job_entrypoint_fnc=lambda _: asyncio.sleep(0),
+        session_end_fnc=None,
+        inference_executor=None,
+        initialize_timeout=1.0,
+        close_timeout=1.0,
+        session_end_timeout=1.0,
+        ping_interval=10.0,
+        high_ping_threshold=10.0,
+        http_proxy=None,
+        loop=loop,
+    )
+
+    executor._pch = AsyncMock()
+    executor._pch.aclose = AsyncMock()
+
+    async def _noop() -> None:
+        return None
+
+    executor._main_atask = asyncio.create_task(_noop())  # marks `started`
+
+    # First aclose: ack times out (future unresolved).
+    await executor.aclose()
+
+    assert not executor._shutdown_ack_fut.cancelled(), (
+        "shield missing: first aclose() cancelled _shutdown_ack_fut (thread)"
+    )
+    assert not executor._shutdown_ack_fut.done()
+
+    executor._main_atask = asyncio.create_task(_noop())
+    try:
+        await executor.aclose()
+    except asyncio.CancelledError as exc:  # pragma: no cover — regression
+        pytest.fail(f"second thread aclose() raised CancelledError (shield regression): {exc!r}")
+
+
+async def test_thread_start_exception_bounds_pch_aclose(monkeypatch):
+    """When `ThreadJobExecutor._start()` raises after `pch` is created,
+    the exception-cleanup `pch.aclose()` must be bounded by
+    `_START_CLEANUP_PCH_ACLOSE_HARD_TIMEOUT_S` and fall back to
+    `_force_close_pch` on timeout — matching the process-side behavior.
+
+    Before this fix, the thread `_start` exception path had a bare
+    `await pch.aclose()` that would hang indefinitely if the duplex
+    flush stalled (the symptom this PR is supposed to defend against).
+    """
+
+    monkeypatch.setattr(job_thread_executor, "_START_CLEANUP_PCH_ACLOSE_HARD_TIMEOUT_S", 0.05)
+
+    fake_pch = MagicMock(spec=duplex_unix._AsyncDuplex)
+
+    async def _hang_aclose() -> None:
+        await asyncio.sleep(60)
+
+    fake_pch.aclose = _hang_aclose
+
+    async def _fake_open(sock):
+        return fake_pch
+
+    monkeypatch.setattr(duplex_unix._AsyncDuplex, "open", staticmethod(_fake_open))
+
+    class _BoomThread:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("simulated thread construction failure")
+
+    monkeypatch.setattr(job_thread_executor.threading, "Thread", _BoomThread)
+
+    force_close_called: list[object] = []
+    monkeypatch.setattr(
+        job_thread_executor,
+        "_force_close_pch",
+        lambda pch: force_close_called.append(pch),
+    )
+
+    loop = asyncio.get_running_loop()
+    executor = ThreadJobExecutor(
+        initialize_process_fnc=lambda _: None,
+        job_entrypoint_fnc=lambda _: asyncio.sleep(0),
+        session_end_fnc=None,
+        inference_executor=None,
+        initialize_timeout=1.0,
+        close_timeout=1.0,
+        session_end_timeout=1.0,
+        ping_interval=10.0,
+        high_ping_threshold=10.0,
+        http_proxy=None,
+        loop=loop,
+    )
+
+    started = loop.time()
+    with pytest.raises(RuntimeError, match="simulated thread construction failure"):
+        await executor.start()
+    elapsed = loop.time() - started
+
+    assert force_close_called == [fake_pch], (
+        "_force_close_pch was not invoked from _start() exception cleanup"
+    )
+    # _start cleanup is bounded by 0.05s pch.aclose timeout; generous slack.
+    assert elapsed < 1.0, f"_start exception cleanup did not bound: {elapsed:.3f}s"

--- a/tests/test_ipc_shutdown_timeouts.py
+++ b/tests/test_ipc_shutdown_timeouts.py
@@ -1,9 +1,9 @@
 """Tests for the parent-side IPC shutdown timeout safety floors.
 
-Verifies that the timeout-wrapping fix introduced for the
-1.4.x/1.5.x parent-side shutdown regression makes
-`InferenceProcExecutor.do_inference` return within a bounded time
-even when the inference proc never responds.
+Verifies that the timeout-wrapping fix introduced for the parent-side
+shutdown regression makes the relevant `aclose()` / `_supervise_task` /
+`do_inference` paths return within a bounded time even when the
+inference proc / child proc never responds.
 
 See:
 - https://github.com/livekit/agents/issues/5497
@@ -15,107 +15,315 @@ See:
 from __future__ import annotations
 
 import asyncio
+import multiprocessing as mp
+import socket
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from livekit.agents.ipc import inference_proc_executor
+from livekit.agents.ipc import (
+    inference_proc_executor,
+    job_proc_executor,
+    proto,
+    supervised_proc,
+)
+from livekit.agents.ipc.inference_proc_executor import InferenceProcExecutor
+from livekit.agents.ipc.supervised_proc import SupervisedProc
+from livekit.agents.utils import aio
 
 
-async def _noop_asend_message(*args, **kwargs):
-    return None
+class _DummySupervisedProc(SupervisedProc):
+    """Concrete SupervisedProc subclass that never actually spawns a process.
+
+    Mirrors the pattern used by tests/test_drain_timeout.py so we avoid
+    `object.__new__` + `# type: ignore` workarounds.
+    """
+
+    def _create_process(self, cch: socket.socket, log_cch: socket.socket) -> mp.Process:
+        raise NotImplementedError
+
+    async def _main_task(self, ipc_ch: aio.ChanReceiver[object]) -> None:
+        raise NotImplementedError
 
 
-@pytest.mark.asyncio
+class _DummyInferenceExecutor(InferenceProcExecutor):
+    """Concrete InferenceProcExecutor subclass for unit testing.
+
+    Avoids spawning real processes / opening real sockets.
+    """
+
+    def _create_process(self, cch: socket.socket, log_cch: socket.socket) -> mp.Process:
+        raise NotImplementedError
+
+    async def _main_task(self, ipc_ch: aio.ChanReceiver[object]) -> None:  # type: ignore[override]
+        raise NotImplementedError
+
+
+def _make_dummy_supervised() -> _DummySupervisedProc:
+    return _DummySupervisedProc(
+        initialize_timeout=1.0,
+        close_timeout=1.0,
+        memory_warn_mb=0.0,
+        memory_limit_mb=0.0,
+        ping_interval=1.0,
+        ping_timeout=1.0,
+        high_ping_threshold=1.0,
+        http_proxy=None,
+        mp_ctx=mp.get_context("spawn"),
+        loop=asyncio.get_event_loop(),
+    )
+
+
+def _make_dummy_inference() -> _DummyInferenceExecutor:
+    return _DummyInferenceExecutor(
+        runners={},
+        initialize_timeout=1.0,
+        close_timeout=1.0,
+        memory_warn_mb=0.0,
+        memory_limit_mb=0.0,
+        ping_interval=1.0,
+        ping_timeout=1.0,
+        high_ping_threshold=1.0,
+        mp_ctx=mp.get_context("spawn"),
+        loop=asyncio.get_event_loop(),
+        http_proxy=None,
+    )
+
+
 async def test_do_inference_raises_runtime_error_on_timeout(monkeypatch):
-    """When the inference proc never responds, ``do_inference`` must raise
-    ``RuntimeError`` within roughly the configured timeout, and must clean
+    """When the inference proc never responds, do_inference must raise
+    RuntimeError within roughly the configured timeout, and must clean
     up its in-flight request entry so it does not leak.
     """
 
-    # Patch the module timeout down to something well under any plausible
-    # CI delay so the test finishes quickly.
-    monkeypatch.setattr(
-        inference_proc_executor,
-        "_INFERENCE_RESPONSE_TIMEOUT_S",
-        0.1,
-    )
+    monkeypatch.setattr(inference_proc_executor, "_INFERENCE_RESPONSE_TIMEOUT_S", 0.1)
 
-    # The `channel.asend_message` call is the only outbound IPC the
-    # function under test performs before awaiting the response future.
-    # Replace it with a noop so we never touch a real socket.
-    monkeypatch.setattr(
-        inference_proc_executor.channel,
-        "asend_message",
-        _noop_asend_message,
-    )
+    async def _noop_asend_message(*args, **kwargs):
+        return None
 
-    executor = object.__new__(inference_proc_executor.InferenceProcExecutor)
-    executor._active_requests = {}
-    executor._pch = None
-    # `started` is `return self._supervise_atask is not None`, so a
-    # truthy sentinel here is enough to satisfy the property without
-    # needing a real asyncio.Task.
-    executor._supervise_atask = object()  # type: ignore[assignment]
-    # `logging_extra()` is called inside the timeout branch.
-    executor.logging_extra = lambda: {}  # type: ignore[method-assign]
+    monkeypatch.setattr(inference_proc_executor.channel, "asend_message", _noop_asend_message)
 
-    loop = asyncio.get_running_loop()
-    started = loop.time()
-    with pytest.raises(RuntimeError) as exc_info:
-        await executor.do_inference("test_method", b"")
-    elapsed = loop.time() - started
+    executor = _make_dummy_inference()
+    executor._supervise_atask = asyncio.create_task(asyncio.sleep(60))
+    executor._pch = AsyncMock()
 
-    assert "timed out" in str(exc_info.value)
-    assert "test_method" in str(exc_info.value)
-    assert elapsed < 1.0, f"do_inference took too long to time out: {elapsed:.3f}s"
-    # The in-flight request entry must be cleaned up on timeout so the
-    # executor does not leak fut references across hangs.
-    assert executor._active_requests == {}
+    try:
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        with pytest.raises(RuntimeError) as exc_info:
+            await executor.do_inference("test_method", b"")
+        elapsed = loop.time() - started
+
+        assert "timed out" in str(exc_info.value)
+        assert "test_method" in str(exc_info.value)
+        assert elapsed < 1.0, f"do_inference took too long to time out: {elapsed:.3f}s"
+        assert executor._active_requests == {}
+    finally:
+        executor._supervise_atask.cancel()
+        with pytest.raises((asyncio.CancelledError, BaseException)):
+            await executor._supervise_atask
 
 
-@pytest.mark.asyncio
 async def test_do_inference_happy_path_returns_response(monkeypatch):
-    """When the inference proc responds, ``do_inference`` must return the
+    """When the inference proc responds, do_inference must return the
     response payload exactly as before — i.e. the new timeout wrap is a
     no-op on the happy path.
     """
 
-    monkeypatch.setattr(
-        inference_proc_executor,
-        "_INFERENCE_RESPONSE_TIMEOUT_S",
-        5.0,
-    )
+    monkeypatch.setattr(inference_proc_executor, "_INFERENCE_RESPONSE_TIMEOUT_S", 5.0)
 
-    executor = object.__new__(inference_proc_executor.InferenceProcExecutor)
-    executor._active_requests = {}
-    executor._pch = None
-    executor._supervise_atask = object()  # type: ignore[assignment]
-    executor.logging_extra = lambda: {}  # type: ignore[method-assign]
+    executor = _make_dummy_inference()
+    executor._supervise_atask = asyncio.create_task(asyncio.sleep(60))
+    executor._pch = AsyncMock()
 
     async def _send_and_resolve(_pch, msg, **kwargs):
-        # Simulate the inference proc responding by completing the
-        # matching future on the next tick. In production, `_main_task`
-        # is the one that pops from `_active_requests` when the response
-        # arrives; mirror that so the dict ends up clean.
         loop = asyncio.get_running_loop()
 
         def _resolve():
             fut = executor._active_requests.pop(msg.request_id, None)
             if fut is not None and not fut.done():
-                from livekit.agents.ipc import proto
-
                 fut.set_result(
                     proto.InferenceResponse(request_id=msg.request_id, data=b"\x01\x02", error="")
                 )
 
         loop.call_soon(_resolve)
 
-    monkeypatch.setattr(
-        inference_proc_executor.channel,
-        "asend_message",
-        _send_and_resolve,
+    monkeypatch.setattr(inference_proc_executor.channel, "asend_message", _send_and_resolve)
+
+    try:
+        data = await executor.do_inference("ok_method", b"")
+        assert data == b"\x01\x02"
+        assert executor._active_requests == {}
+    finally:
+        executor._supervise_atask.cancel()
+        with pytest.raises((asyncio.CancelledError, BaseException)):
+            await executor._supervise_atask
+
+
+async def test_shutting_down_fut_timeout_triggers_kill(monkeypatch):
+    """When the child never sends ShuttingDown, aclose() must time out
+    within _SHUTTING_DOWN_HARD_TIMEOUT_S and escalate to dump+kill.
+
+    This is the only escalating fallback path in the new wraps — if it
+    silently regresses, prod symptom is identical to pre-PR.
+    """
+
+    monkeypatch.setattr(supervised_proc, "_SHUTTING_DOWN_HARD_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(supervised_proc, "_SHUTDOWN_ACK_HARD_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(supervised_proc, "_SUPERVISE_HARD_TIMEOUT_S", 0.05)
+
+    proc = _make_dummy_supervised()
+    proc._pch = AsyncMock()
+    proc._pch.aclose = AsyncMock()
+    # Resolve shutdown_ack synthetically so we focus on the shutting_down branch.
+    proc._shutdown_ack_fut.set_result(None)
+    # Leave _shutting_down_fut unresolved — that's what triggers the timeout.
+
+    # A `started`-truthy supervise task that completes promptly so the
+    # second supervise wait in aclose() doesn't also need to escalate.
+    async def _quick() -> None:
+        return None
+
+    proc._supervise_atask = asyncio.create_task(_quick())
+
+    dump_calls: list[None] = []
+    kill_calls: list[None] = []
+
+    async def _dump() -> None:
+        dump_calls.append(None)
+
+    async def _kill() -> None:
+        kill_calls.append(None)
+
+    monkeypatch.setattr(proc, "_send_dump_signal", _dump)
+    monkeypatch.setattr(proc, "_send_kill_signal", _kill)
+
+    await proc.aclose()
+
+    # Dump+kill should be invoked at least once via the shutting_down branch.
+    assert len(dump_calls) >= 1
+    assert len(kill_calls) >= 1
+
+
+async def test_kill_supervise_timeout_logs_and_returns(monkeypatch):
+    """When supervise_atask hangs after kill(), kill() must return
+    within _KILL_SUPERVISE_HARD_TIMEOUT_S rather than waiting forever.
+    """
+
+    monkeypatch.setattr(supervised_proc, "_KILL_SUPERVISE_HARD_TIMEOUT_S", 0.05)
+
+    proc = _make_dummy_supervised()
+
+    # Hanging supervise task — never completes naturally.
+    proc._supervise_atask = asyncio.create_task(asyncio.sleep(60))
+
+    async def _noop() -> None:
+        return None
+
+    monkeypatch.setattr(proc, "_send_dump_signal", _noop)
+    monkeypatch.setattr(proc, "_send_kill_signal", _noop)
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    try:
+        await proc.kill()
+    finally:
+        proc._supervise_atask.cancel()
+        with pytest.raises((asyncio.CancelledError, BaseException)):
+            await proc._supervise_atask
+    elapsed = loop.time() - started
+
+    assert elapsed < 1.0, f"kill() did not bound: {elapsed:.3f}s"
+
+
+async def test_main_task_inference_cancel_timeout_bounds(monkeypatch):
+    """job_proc_executor._main_task finally must bound the cancel of
+    pending inference tasks within the configured hard timeout, even
+    when those tasks ignore CancelledError. Without the wrap, this
+    would block _supervise_task cleanup forever and keep a K8s pod
+    Terminating.
+    """
+
+    monkeypatch.setattr(job_proc_executor, "_INFERENCE_TASKS_CANCEL_HARD_TIMEOUT_S", 0.05)
+
+    proc = job_proc_executor.ProcJobExecutor(
+        initialize_process_fnc=lambda _: None,
+        job_entrypoint_fnc=lambda _: asyncio.sleep(0),
+        session_end_fnc=None,
+        inference_executor=None,
+        initialize_timeout=1.0,
+        close_timeout=1.0,
+        session_end_timeout=1.0,
+        memory_warn_mb=0.0,
+        memory_limit_mb=0.0,
+        ping_interval=1.0,
+        ping_timeout=1.0,
+        high_ping_threshold=1.0,
+        http_proxy=None,
+        mp_ctx=mp.get_context("spawn"),
+        loop=asyncio.get_event_loop(),
     )
 
-    data = await executor.do_inference("ok_method", b"")
-    assert data == b"\x01\x02"
-    assert executor._active_requests == {}
+    # A stuck inference task that ignores cancel — emulates the leak
+    # this PR is supposed to bound.
+    async def _stuck() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            await asyncio.sleep(60)
+
+    stuck = asyncio.create_task(_stuck())
+    proc._inference_tasks.add(stuck)
+
+    ipc_ch: aio.Chan[object] = aio.Chan()
+    ipc_ch.close()
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    try:
+        await proc._main_task(ipc_ch)  # type: ignore[arg-type]
+    finally:
+        stuck.cancel()
+    elapsed = loop.time() - started
+
+    # _main_task must return well within the 60s sleeps the stuck task
+    # is wedged in. Allow generous CI scheduling slack.
+    assert elapsed < 2.0, f"_main_task did not bound: {elapsed:.3f}s"
+
+
+async def test_pch_aclose_timeout_force_closes_sock(monkeypatch):
+    """When pch.aclose() hangs, the timeout branch must force-close
+    the underlying transport + socket to release the fd promptly.
+    """
+
+    monkeypatch.setattr(supervised_proc, "_PCH_ACLOSE_HARD_TIMEOUT_S", 0.05)
+
+    force_close_called: list[object] = []
+
+    def _capture_force_close(pch):
+        force_close_called.append(pch)
+
+    monkeypatch.setattr(supervised_proc, "_force_close_pch", _capture_force_close)
+
+    # Direct call into the helper path: run the body that wraps pch.aclose
+    # via a minimal harness. Use a hanging coroutine to emulate aclose
+    # never resolving.
+    import contextlib
+
+    async def _hang() -> None:
+        await asyncio.sleep(60)
+
+    fake_pch = MagicMock()
+    fake_pch.aclose = _hang
+
+    with contextlib.suppress(asyncio.TimeoutError):
+        try:
+            await asyncio.wait_for(
+                fake_pch.aclose(),
+                timeout=supervised_proc._PCH_ACLOSE_HARD_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            supervised_proc._force_close_pch(fake_pch)
+            raise
+
+    assert force_close_called == [fake_pch]

--- a/tests/test_ipc_shutdown_timeouts.py
+++ b/tests/test_ipc_shutdown_timeouts.py
@@ -1,0 +1,121 @@
+"""Tests for the parent-side IPC shutdown timeout safety floors.
+
+Verifies that the timeout-wrapping fix introduced for the
+1.4.x/1.5.x parent-side shutdown regression makes
+`InferenceProcExecutor.do_inference` return within a bounded time
+even when the inference proc never responds.
+
+See:
+- https://github.com/livekit/agents/issues/5497
+- https://github.com/livekit/agents/issues/3174
+- https://github.com/livekit/agents/pull/4580 (regression source)
+- https://github.com/livekit/agents/pull/5602 (child-side complement)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents.ipc import inference_proc_executor
+
+
+async def _noop_asend_message(*args, **kwargs):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_do_inference_raises_runtime_error_on_timeout(monkeypatch):
+    """When the inference proc never responds, ``do_inference`` must raise
+    ``RuntimeError`` within roughly the configured timeout, and must clean
+    up its in-flight request entry so it does not leak.
+    """
+
+    # Patch the module timeout down to something well under any plausible
+    # CI delay so the test finishes quickly.
+    monkeypatch.setattr(
+        inference_proc_executor,
+        "_INFERENCE_RESPONSE_TIMEOUT_S",
+        0.1,
+    )
+
+    # The `channel.asend_message` call is the only outbound IPC the
+    # function under test performs before awaiting the response future.
+    # Replace it with a noop so we never touch a real socket.
+    monkeypatch.setattr(
+        inference_proc_executor.channel,
+        "asend_message",
+        _noop_asend_message,
+    )
+
+    executor = object.__new__(inference_proc_executor.InferenceProcExecutor)
+    executor._active_requests = {}
+    executor._pch = None
+    # `started` is `return self._supervise_atask is not None`, so a
+    # truthy sentinel here is enough to satisfy the property without
+    # needing a real asyncio.Task.
+    executor._supervise_atask = object()  # type: ignore[assignment]
+    # `logging_extra()` is called inside the timeout branch.
+    executor.logging_extra = lambda: {}  # type: ignore[method-assign]
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    with pytest.raises(RuntimeError) as exc_info:
+        await executor.do_inference("test_method", b"")
+    elapsed = loop.time() - started
+
+    assert "timed out" in str(exc_info.value)
+    assert "test_method" in str(exc_info.value)
+    assert elapsed < 1.0, f"do_inference took too long to time out: {elapsed:.3f}s"
+    # The in-flight request entry must be cleaned up on timeout so the
+    # executor does not leak fut references across hangs.
+    assert executor._active_requests == {}
+
+
+@pytest.mark.asyncio
+async def test_do_inference_happy_path_returns_response(monkeypatch):
+    """When the inference proc responds, ``do_inference`` must return the
+    response payload exactly as before — i.e. the new timeout wrap is a
+    no-op on the happy path.
+    """
+
+    monkeypatch.setattr(
+        inference_proc_executor,
+        "_INFERENCE_RESPONSE_TIMEOUT_S",
+        5.0,
+    )
+
+    executor = object.__new__(inference_proc_executor.InferenceProcExecutor)
+    executor._active_requests = {}
+    executor._pch = None
+    executor._supervise_atask = object()  # type: ignore[assignment]
+    executor.logging_extra = lambda: {}  # type: ignore[method-assign]
+
+    async def _send_and_resolve(_pch, msg, **kwargs):
+        # Simulate the inference proc responding by completing the
+        # matching future on the next tick. In production, `_main_task`
+        # is the one that pops from `_active_requests` when the response
+        # arrives; mirror that so the dict ends up clean.
+        loop = asyncio.get_running_loop()
+
+        def _resolve():
+            fut = executor._active_requests.pop(msg.request_id, None)
+            if fut is not None and not fut.done():
+                from livekit.agents.ipc import proto
+
+                fut.set_result(
+                    proto.InferenceResponse(request_id=msg.request_id, data=b"\x01\x02", error="")
+                )
+
+        loop.call_soon(_resolve)
+
+    monkeypatch.setattr(
+        inference_proc_executor.channel,
+        "asend_message",
+        _send_and_resolve,
+    )
+
+    data = await executor.do_inference("ok_method", b"")
+    assert data == b"\x01\x02"
+    assert executor._active_requests == {}


### PR DESCRIPTION
## Summary

The parent-side IPC shutdown chain has multiple unbounded `await`s that can keep a K8s pod **Terminating for the full graceful-shutdown grace period** (in this fork's deploy config: 18000s = 5h) when cancel propagation races with a future being set, when a duplex socket close blocks, or when a child fails to send `ShuttingDown`.

This PR adds **defense-in-depth hard timeouts** to six awaits so `proc.aclose()` always returns within a bounded time, regardless of which underlying step stalls.

## Production evidence

`voxai-agent-v2-dd9d64f7-zz84g` (image `cbc991e-v2.1.682`), SIGTERM at 2026-05-21T08:00:45Z:

- Active calls completed normally (active_job_count: 2 → 4 → 3 → 2 → 1 → 0 within 90s after SIGTERM).
- All in-flight jobs reached `job_ctx_on_session_end_done` per vox `shutdown_trace`.
- Parent SIGABRT dump (11min after SIGTERM) shows main asyncio loop in `cli.py:1626 _run_worker → server.drain()`, no `supervised_proc._sync_run` thread (children joined).
- `worker.py:932 await asyncio.gather(*self._job_lifecycle_tasks)` never completed.

Root cause: at least one of the six unbounded awaits in the parent-side shutdown chain failed to resolve, blocking `_supervise_atask` and consequently `aclose() L293 wait_for(supervise_atask, timeout=close_timeout=18000s)`.

## Sites wrapped

Each timeout fires a unique greppable error log token so SRE can dashboard on it:

| File:line (old) | Token | Fallback on timeout |
|---|---|---|
| `inference_proc_executor.py:97 await fut` | `[ipc.inference_response_timeout]` | Raise `RuntimeError`, cleanup `_active_requests` |
| `supervised_proc.py:289 await _shutting_down_fut` | `[ipc.shutting_down_timeout]` | `_send_dump_signal` + `_send_kill_signal` |
| `supervised_proc.py:306 lock-protected shield(supervise_atask)` | `[ipc.supervise_atask_timeout]` | Drop + continue |
| `supervised_proc.py:396 cancel_and_wait(helpers)` | `[ipc.helpers_cancel_timeout]` | Drop + continue (also wraps memory_monitor cancel) |
| `supervised_proc.py:402 await pch.aclose()` | `[ipc.pch_aclose_timeout]` | Drop + continue |
| `job_proc_executor.py:122 cancel_and_wait(*inference_tasks)` | `[ipc.main_task_inference_cancel_timeout]` | Drop + continue |

Default timeouts: 10.0s for the IPC-response style awaits, 5.0s for `pch.aclose()`. All four supervised_proc timeouts are module-local constants (`_SHUTTING_DOWN_HARD_TIMEOUT_S`, `_SUPERVISE_HARD_TIMEOUT_S`, `_HELPERS_CANCEL_HARD_TIMEOUT_S`, `_PCH_ACLOSE_HARD_TIMEOUT_S`). The `inference_proc_executor` and `job_proc_executor` constants are similar.

## Scope

- **Library-internal safety floor** — NO new `WorkerOptions` config, NO public API change.
- Existing `close_timeout` behavior unchanged on the happy path.
- AgentSession side (child-side close path) NOT touched — that is upstream PR #5602's territory.

## Cause / history

- The `_main_task` finally `cancel_and_wait`, `_supervise_task` post-join `cancel_and_wait`, `pch.aclose()`, and `do_inference` `await fut` all exist verbatim in 1.4.6 (same code, same lack of timeout). **This is not strictly a 1.5.x regression for those four**.
- The two NEW awaits inside `aclose` (`_shutting_down_fut`, lock-protected `shield(supervise_atask)`) were added by upstream **PR #4580** (1.5.x).
- Vox's `shutdown_process_timeout=18000.0` (`app_lk.py:691`) makes the existing `close_timeout`-bounded waits effectively unbounded.

## References

- https://github.com/livekit/agents/issues/5497 (OPEN; AgentSession-side same regression)
- https://github.com/livekit/agents/issues/3174 (CLOSED; same symptom reported on 1.2)
- https://github.com/livekit/agents/pull/4580 (regression source — `_shutting_down_fut`)
- https://github.com/livekit/agents/pull/5602 (child-side complement, still OPEN)

## Test plan

- [x] `make check` (format + lint + type-check)
- [x] `uv run pytest tests/test_ipc_shutdown_timeouts.py -q` (new test, 2 passed)
- [x] `uv run pytest tests/test_ipc.py -q` (8 passed)
- [x] `uv run pytest tests/test_audio_recognition_aclose.py -q` (2 passed)
- [x] `uv run pytest tests/test_agent_session.py -q` (24 passed)
- [ ] Deploy to staging, observe drain stage logs progress past `job_lifecycle_tasks_done` within bounded time when SIGTERM arrives with in-flight inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)