### PR TITLE
chore(agents): drain diagnostics 로그 레벨 info→debug

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -899,7 +899,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
 
             logger.info("draining worker", extra={"id": self.id, "timeout": timeout})
             self._draining = True
-            logger.info(
+            logger.debug(
                 "drain stage",
                 extra={
                     "id": self.id,
@@ -908,7 +908,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 },
             )
             await self._update_worker_status()
-            logger.info(
+            logger.debug(
                 "drain stage",
                 extra={
                     "id": self.id,
@@ -920,7 +920,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             async def _drain() -> None:
                 # wait for in-flight availability tasks to finish launching their jobs
                 pending_tasks = [t for t in self._job_lifecycle_tasks if not t.done()]
-                logger.info(
+                logger.debug(
                     "drain stage",
                     extra={
                         "id": self.id,
@@ -930,7 +930,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                     },
                 )
                 await asyncio.gather(*self._job_lifecycle_tasks, return_exceptions=True)
-                logger.info(
+                logger.debug(
                     "drain stage",
                     extra={"id": self.id, "stage": "job_lifecycle_tasks_done"},
                 )
@@ -938,7 +938,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 # then wait for the launched jobs to complete
                 while True:
                     procs = [p for p in self._proc_pool.processes if p.running_job]
-                    logger.info(
+                    logger.debug(
                         "drain stage",
                         extra={
                             "id": self.id,
@@ -950,7 +950,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                     if not procs:
                         break
                     for proc in procs:
-                        logger.info(
+                        logger.debug(
                             "drain stage",
                             extra={
                                 "id": self.id,
@@ -959,7 +959,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                             },
                         )
                         await proc.join()
-                        logger.info(
+                        logger.debug(
                             "drain stage",
                             extra={
                                 "id": self.id,
@@ -1083,7 +1083,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
 
         which = msg.WhichOneof("message")
         if self._draining or self._msg_chan.full():
-            logger.info(
+            logger.debug(
                 "worker message queue send start",
                 extra={
                     "id": self.id,
@@ -1095,7 +1095,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             )
         await self._msg_chan.send(msg)
         if self._draining or self._msg_chan.full():
-            logger.info(
+            logger.debug(
                 "worker message queue send done",
                 extra={
                     "id": self.id,


### PR DESCRIPTION
## 요약
- f48e8f10 / ff4f2b1d / a6baa26c 에서 추가된 drain 진단 로그를 `logger.info` → `logger.debug`로 낮춤
- 대상: `drain stage` (7곳), `worker message queue send start/done` (2곳) — 총 9곳
- 기존 `draining worker` / `shutting down worker` info 로그는 유지

## 배경
이 로그들은 drain 셧다운 경로의 디버그용 breadcrumb인데, info 레벨이라 정상 운영 중에도 노이즈가 누적됨. 진단용이라는 의도에 맞게 debug 레벨로 내림. `LIVEKIT_LOG_LEVEL=debug` 또는 ServerOptions로 켤 수 있음.

## Test plan
- [ ] `make lint` 통과
- [ ] `make type-check` 통과
- [ ] dev/staging에서 worker drain 시점에 info 로그 안 나오는지 확인
- [ ] `LIVEKIT_LOG_LEVEL=debug`로 띄우면 기존 진단 로그가 정상 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)