### PR TITLE
fix: add process init observability

### DIFF
--- a/livekit-agents/livekit/agents/ipc/proc_client.py
+++ b/livekit-agents/livekit/agents/ipc/proc_client.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import socket
 import sys
+import time
 from collections.abc import Coroutine
 from types import FrameType
 from typing import Callable
@@ -34,6 +35,7 @@ class _ProcClient:
         self._initialized = False
 
     def initialize(self) -> None:
+        start_time = time.perf_counter()
         try:
             cch = aio.duplex_unix._Duplex.open(self._mp_cch)
             first_req = recv_message(cch, IPC_MESSAGES)
@@ -43,16 +45,47 @@ class _ProcClient:
             )
 
             self._init_req = first_req
+            logger.info("process_init_step", extra={"step": "initialize_request_received"})
             try:
+                setup_start_time = time.perf_counter()
+                logger.info("process_init_step", extra={"step": "initialize_fnc_start"})
                 self._initialize_fnc(self._init_req, self)
+                logger.info(
+                    "process_init_step",
+                    extra={
+                        "step": "initialize_fnc_complete",
+                        "elapsed_time": round(time.perf_counter() - setup_start_time, 2),
+                    },
+                )
                 send_message(cch, InitializeResponse())
+                logger.info(
+                    "process_init_step",
+                    extra={
+                        "step": "initialize_response_sent",
+                        "elapsed_time": round(time.perf_counter() - start_time, 2),
+                    },
+                )
             except Exception as e:
+                logger.exception(
+                    "process_init_step_failed",
+                    extra={
+                        "step": "initialize_fnc_failed",
+                        "elapsed_time": round(time.perf_counter() - start_time, 2),
+                    },
+                )
                 send_message(cch, InitializeResponse(error=str(e)))
                 raise
 
             self._initialized = True
             cch.detach()
         except aio.duplex_unix.DuplexClosed as e:
+            logger.exception(
+                "process_init_step_failed",
+                extra={
+                    "step": "initialize_ipc_closed",
+                    "elapsed_time": round(time.perf_counter() - start_time, 2),
+                },
+            )
             raise RuntimeError("failed to initialize proc_client") from e
 
     def run(self) -> None:
@@ -165,6 +198,7 @@ def _dump_stack_traces_impl() -> None:
     dir: str = os.getenv("LK_DUMP_DIR", tempfile.gettempdir())
     Path(dir).mkdir(parents=True, exist_ok=True)
 
+    dump_path = None
     with tempfile.NamedTemporaryFile(
         mode="w",
         dir=dir,
@@ -172,6 +206,7 @@ def _dump_stack_traces_impl() -> None:
         prefix=f"livekit-agents-pid-{current_process().pid}-{time.time_ns()}-",
         suffix=".stacktrace",
     ) as f:
+        dump_path = f.name
         print(f"\n{'=' * 60}", file=f)
         print(
             f"Process {current_process().name} (pid {current_process().pid}) stack trace dump",
@@ -250,6 +285,9 @@ def _dump_stack_traces_impl() -> None:
             print(f"VMS: {memory_info.vms / (1024 * 1024):.2f} MB", file=f)
         except Exception:
             pass
+
+    if dump_path is not None:
+        print(f"livekit agents stack trace dumped to {dump_path}", file=sys.stderr, flush=True)
 
 
 def _dump_stack_traces(signum: int, _: FrameType | None) -> None:

--- a/livekit-agents/livekit/agents/ipc/proc_pool.py
+++ b/livekit-agents/livekit/agents/ipc/proc_pool.py
@@ -176,8 +176,20 @@ class ProcPool(utils.EventEmitter[EventTypes]):
                 self._warmed_proc_queue.put_nowait(proc)
                 if self._warmed_proc_queue.qsize() >= self._default_num_idle_processes:
                     self._idle_ready.set()
-            except Exception:
-                logger.exception("error initializing process", extra=proc.logging_extra())
+            except Exception as e:
+                logger.exception(
+                    "error initializing process",
+                    extra={
+                        **proc.logging_extra(),
+                        "error_type": type(e).__name__,
+                        "initialize_timeout": self._initialize_timeout,
+                        "warmed_processes": self._warmed_proc_queue.qsize(),
+                        "spawn_tasks": len(self._spawn_tasks),
+                        "jobs_waiting_for_process": self._jobs_waiting_for_process,
+                        "target_idle_processes": self._target_idle_processes,
+                        "default_num_idle_processes": self._default_num_idle_processes,
+                    },
+                )
 
         monitor_task = asyncio.create_task(self._monitor_process_task(proc))
         self._monitor_tasks.add(monitor_task)

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -230,6 +230,14 @@ class SupervisedProc(ABC):
             self._initialize_fut.set_exception(
                 asyncio.TimeoutError("process initialization timed out")
             )
+            logger.error(
+                "process initialization timed out",
+                extra={
+                    **self.logging_extra(),
+                    "initialize_timeout": self._opts.initialize_timeout,
+                    "stack_trace_dump_enabled": self.enabled_stack_trace_dump,
+                },
+            )
             await self._send_dump_signal()
             await self._send_kill_signal()
             raise


### PR DESCRIPTION
## Summary\n- log child-side process initialization milestones around InitializeRequest, initialize_fnc, and InitializeResponse\n- add parent-side init timeout/error context including pool queue sizes, timeout, and spawn pressure\n- print stack trace dump file path so GCP logs can point to the child dump artifact\n\n## Context\nSlack thread C0AR1BHP5CJ / 1781225941.980269 diagnosed orphaned queued calls caused by warm process starvation after repeated child init timeout/cancel events. The missing evidence was the child-side last init step and dump path.\n\n## Verification\n- uv run ruff check livekit-agents/livekit/agents/ipc/proc_client.py livekit-agents/livekit/agents/ipc/proc_pool.py livekit-agents/livekit/agents/ipc/supervised_proc.py\n- uv run ruff format --check livekit-agents/livekit/agents/ipc/proc_client.py livekit-agents/livekit/agents/ipc/proc_pool.py livekit-agents/livekit/agents/ipc/supervised_proc.py\n- uv run python -m py_compile livekit-agents/livekit/agents/ipc/proc_client.py livekit-agents/livekit/agents/ipc/proc_pool.py livekit-agents/livekit/agents/ipc/supervised_proc.py