### PR TITLE
feat(voice): barge-in source 이벤트 sink 추가

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4213,6 +4213,13 @@ class AgentActivity(RecognitionHooks):
             }
             if extra:
                 metadata.update(extra)
+            try:
+                context = self._session.userdata
+                sink = getattr(context, "barge_in_source_event_sink", None)
+                if callable(sink):
+                    sink(self._session, event=event, metadata=dict(metadata))
+            except Exception:
+                logger.debug("failed to publish barge-in source diagnostic", exc_info=True)
             logger.info(event, extra=metadata)
         except Exception:
             logger.debug("failed to emit barge-in source diagnostic", exc_info=True)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -161,6 +161,20 @@ def _truncate_interruption_text(text: str | None, limit: int = 80) -> str | None
     return normalized[:limit] + "..."
 
 
+_BARGE_IN_SOURCE_ALIASES = {
+    "vad": "livekit_vad",
+    "vad_start": "livekit_vad_start",
+    "overlap": "livekit_overlap",
+    "interim": "main_stt_interim",
+    "preflight": "main_stt_preflight",
+    "final": "main_stt_final",
+}
+
+
+def _barge_in_source(source: str) -> str:
+    return _BARGE_IN_SOURCE_ALIASES.get(source, source or "unknown")
+
+
 @dataclass
 class _OnEnterData:
     session: AgentSession
@@ -207,6 +221,7 @@ class _PausedSpeechInfo:
     handle: SpeechHandle
     agent_state: AgentState
     timeout: float
+    source: str | None = None
 
 
 # NOTE: AgentActivity isn't exposed to the public API
@@ -262,6 +277,7 @@ class AgentActivity(RecognitionHooks):
         self._agent_ttft_by_speech: dict[str, float] = {}
         self._user_speech_started_during_interruptible_agent_speech = False
         self._dynamic_interruption = DynamicInterruptionManager(self._opts)
+        self._barge_in_source_event_keys: set[tuple[str, str, str | None]] = set()
 
         if (
             isinstance(self.llm, llm.RealtimeModel)
@@ -1913,23 +1929,70 @@ class AgentActivity(RecognitionHooks):
                 if text_hint is not None and opts.interruption_ignore_words
                 else None
             )
-            if dyn_min_words > 0:
-                # TODO(long): better word splitting for multi-language
-                if word_count < dyn_min_words:
-                    return
-
-            # voxai: interruption ignore words
+            short_transcript = dyn_min_words > 0 and word_count < dyn_min_words
+            is_empty = text.strip() == ""
             if opts.interruption_ignore_words:
-                is_empty = text.strip() == ""
-                if is_empty and dyn_min_words > 0:
-                    return
                 ignore_match = (
                     _matches_ignore_words(text, opts.interruption_ignore_words)
                     if not is_empty
                     else None
                 )
+            candidate_result = "candidate"
+            if short_transcript:
+                candidate_result = "min_words"
+            elif is_empty and dyn_min_words > 0 and opts.interruption_ignore_words:
+                candidate_result = "empty_interruption"
+            elif ignore_match:
+                candidate_result = "interruption_ignore_words"
+            self._log_barge_in_source_event(
+                "barge_in_source_candidate",
+                source=source,
+                text_hint=text_hint,
+                current_transcript=text,
+                dyn_min_words=dyn_min_words,
+                word_count=word_count,
+                ignore_match=ignore_match,
+                event_ignore_match=event_ignore_match,
+                once=True,
+                extra={
+                    "candidate_result": candidate_result,
+                    "has_current_speech": self._current_speech is not None,
+                    "agent_state": self._session.agent_state,
+                    "will_evaluate_current_speech": (
+                        self._current_speech is not None
+                        and not self._current_speech.interrupted
+                        and self._current_speech.allow_interruptions
+                    ),
+                },
+            )
+            if dyn_min_words > 0:
+                # TODO(long): better word splitting for multi-language
+                if short_transcript:
+                    return
+
+            # voxai: interruption ignore words
+            if opts.interruption_ignore_words:
+                if is_empty and dyn_min_words > 0:
+                    return
                 if ignore_match:
                     return
+        else:
+            self._log_barge_in_source_event(
+                "barge_in_source_candidate",
+                source=source,
+                text_hint=text_hint,
+                once=True,
+                extra={
+                    "candidate_result": "candidate",
+                    "has_current_speech": self._current_speech is not None,
+                    "agent_state": self._session.agent_state,
+                    "will_evaluate_current_speech": (
+                        self._current_speech is not None
+                        and not self._current_speech.interrupted
+                        and self._current_speech.allow_interruptions
+                    ),
+                },
+            )
 
         if self._rt_session is not None:
             self._rt_session.start_user_activity()
@@ -1963,11 +2026,29 @@ class AgentActivity(RecognitionHooks):
             # that reaches the speech-interrupt branch, regardless of pause vs
             # interrupt path; `reason` discriminates the two.
             will_pause = self._pause_enabled()
+            reason = "pause_current_speech" if will_pause else "interrupt_current_speech"
+            self._log_barge_in_source_event(
+                "barge_in_source_commit",
+                source=source,
+                text_hint=text_hint,
+                current_transcript=text,
+                dyn_min_words=dyn_min_words,
+                word_count=word_count,
+                ignore_match=ignore_match,
+                event_ignore_match=event_ignore_match,
+                once=True,
+                extra={
+                    "reason": reason,
+                    "will_pause": will_pause,
+                    "will_interrupt": True,
+                    "agent_state": self._session.agent_state,
+                },
+            )
             logger.info(
                 "interruption_candidate",
                 extra={
                     "source": source,
-                    "reason": "pause_current_speech" if will_pause else "interrupt_current_speech",
+                    "reason": reason,
                     "event_text": _truncate_interruption_text(text_hint),
                     "current_transcript": _truncate_interruption_text(text),
                     "dyn_min_words": dyn_min_words,
@@ -1985,7 +2066,7 @@ class AgentActivity(RecognitionHooks):
                 assert (timeout := interruption_options["false_interruption_timeout"]) is not None
                 assert (audio_output := self._session.output.audio) is not None
 
-                self._update_paused_speech(self._current_speech, timeout)
+                self._update_paused_speech(self._current_speech, timeout, source=source)
                 audio_output.pause()
                 self._session._update_agent_state("listening")
                 if self._audio_recognition:
@@ -2040,7 +2121,7 @@ class AgentActivity(RecognitionHooks):
             # resume immediately when user stops speaking, the timeout will be updated by _interrupt_by_audio_activity
             assert (audio_output := self._session.output.audio) is not None
 
-            self._update_paused_speech(current_speech, timeout=0)
+            self._update_paused_speech(current_speech, timeout=0, source="vad_start")
             audio_output.pause()
 
     def on_end_of_speech(self, ev: vad.VADEvent | None) -> None:
@@ -2297,10 +2378,42 @@ class AgentActivity(RecognitionHooks):
         ):
             opts = self._session.options
             min_words = self._get_dynamic_min_interruption_words()
-            if (
-                min_words > 0
-                and len(split_words(info.new_transcript, split_character=True)) < min_words
+            word_count = len(split_words(info.new_transcript, split_character=True))
+            final_ignore_match = (
+                _matches_ignore_words(info.new_transcript, opts.interruption_ignore_words)
+                if info.new_transcript.strip() and opts.interruption_ignore_words
+                else None
+            )
+            final_candidate_result = "candidate"
+            if min_words > 0 and word_count < min_words:
+                final_candidate_result = "min_words"
+            elif (
+                info.new_transcript.strip() == ""
+                and min_words > 0
+                and opts.interruption_ignore_words
             ):
+                final_candidate_result = "empty_interruption"
+            elif final_ignore_match:
+                final_candidate_result = "interruption_ignore_words"
+            self._log_barge_in_source_event(
+                "barge_in_source_candidate",
+                source="final",
+                text_hint=info.new_transcript,
+                current_transcript=info.new_transcript,
+                dyn_min_words=min_words,
+                word_count=word_count,
+                ignore_match=final_ignore_match,
+                event_ignore_match=final_ignore_match,
+                once=True,
+                extra={
+                    "candidate_result": final_candidate_result,
+                    "delayed_interruption_context": delayed_interruption_context,
+                    "has_current_speech": self._current_speech is not None,
+                    "agent_state": self._session.agent_state,
+                    "will_evaluate_current_speech": current_speech_interruptible,
+                },
+            )
+            if min_words > 0 and word_count < min_words:
                 self._cancel_preemptive_generation(reason="min_interruption_words")
                 # avoid interruption if the new_transcript is too short
                 if delayed_interruption_context:
@@ -2321,9 +2434,7 @@ class AgentActivity(RecognitionHooks):
                             reason="empty_interruption",
                         )
                     return False
-                if (not is_empty) and _matches_ignore_words(
-                    info.new_transcript, opts.interruption_ignore_words
-                ):
+                if (not is_empty) and final_ignore_match:
                     self._cancel_preemptive_generation(reason="interruption_ignore_words")
                     if delayed_interruption_context:
                         return self._consume_delayed_interruption_turn(
@@ -2331,6 +2442,23 @@ class AgentActivity(RecognitionHooks):
                             reason="interruption_ignore_words",
                         )
                     return False
+            self._log_barge_in_source_event(
+                "barge_in_source_commit",
+                source="final",
+                text_hint=info.new_transcript,
+                current_transcript=info.new_transcript,
+                dyn_min_words=min_words,
+                word_count=word_count,
+                ignore_match=final_ignore_match,
+                event_ignore_match=final_ignore_match,
+                once=True,
+                extra={
+                    "reason": "commit_user_turn",
+                    "delayed_interruption_context": delayed_interruption_context,
+                    "will_interrupt": current_speech_interruptible,
+                    "agent_state": self._session.agent_state,
+                },
+            )
 
         old_task = self._user_turn_completed_atask
         self._user_turn_completed_atask = self._create_speech_task(
@@ -3898,11 +4026,13 @@ class AgentActivity(RecognitionHooks):
                     f"Tool reply cannot be prevented when using {self.llm._label}, it generates reply automatically."
                 )
 
-    def _update_paused_speech(self, speech_handle: SpeechHandle, timeout: float) -> None:
+    def _update_paused_speech(
+        self, speech_handle: SpeechHandle, timeout: float, *, source: str | None = None
+    ) -> None:
         """Record that ``speech_handle`` is paused.
 
         If already paused for this handle, only ``timeout`` is updated — the
-        ``agent_state`` captured at first pause is preserved, so the resume
+        ``agent_state`` and source captured at first pause are preserved, so the resume
         path restores the correct state even across multiple calls.
         """
         if self._paused_speech and self._paused_speech.handle is speech_handle:
@@ -3912,6 +4042,7 @@ class AgentActivity(RecognitionHooks):
                 handle=speech_handle,
                 agent_state=self._session.agent_state,
                 timeout=timeout,
+                source=source,
             )
 
     def _pause_enabled(self) -> bool:
@@ -3954,6 +4085,12 @@ class AgentActivity(RecognitionHooks):
                 resumed = True
                 logger.debug("resumed false interrupted speech", extra={"timeout": timeout})
 
+            self._log_barge_in_source_event(
+                "barge_in_source_false_interrupt",
+                source=self._paused_speech.source or "unknown",
+                once=False,
+                extra={"resumed": resumed, "timeout": timeout},
+            )
             self._session.emit(
                 "agent_false_interruption", AgentFalseInterruptionEvent(resumed=resumed)
             )
@@ -4027,6 +4164,74 @@ class AgentActivity(RecognitionHooks):
         self._interruption_by_audio_activity_enabled = (
             self._default_interruption_by_audio_activity_enabled
         )
+
+    def _log_barge_in_source_event(
+        self,
+        event: str,
+        *,
+        source: str,
+        text_hint: str | None = None,
+        current_transcript: str | None = None,
+        dyn_min_words: int = 0,
+        word_count: int = 0,
+        ignore_match: bool | None = None,
+        event_ignore_match: bool | None = None,
+        once: bool = False,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        try:
+            speech = self._current_speech or (
+                self._paused_speech.handle if self._paused_speech else None
+            )
+            speech_id = getattr(speech, "id", None)
+            source_name = _barge_in_source(source)
+            if once:
+                seen = getattr(self, "_barge_in_source_event_keys", None)
+                if seen is None:
+                    seen = set()
+                    self._barge_in_source_event_keys = seen
+                key = (event, source_name, speech_id)
+                if key in seen:
+                    return
+                seen.add(key)
+
+            metadata: dict[str, Any] = {
+                "source": source_name,
+                "raw_source": source,
+                "perf_ts": time.perf_counter(),
+                "wall_ts": time.time(),
+                "agent_activity_id": hex(id(self)),
+                "speech_id": speech_id,
+                "generation_id": getattr(speech, "_generation_id", None),
+                "event_text": _truncate_interruption_text(text_hint),
+                "current_transcript": _truncate_interruption_text(current_transcript),
+                "dyn_min_words": dyn_min_words,
+                "word_count": word_count,
+                "ignore_match": ignore_match,
+                "event_ignore_match": event_ignore_match,
+                **self._barge_in_context_fields(),
+            }
+            if extra:
+                metadata.update(extra)
+            logger.info(event, extra=metadata)
+        except Exception:
+            logger.debug("failed to emit barge-in source diagnostic", exc_info=True)
+
+    def _barge_in_context_fields(self) -> dict[str, Any]:
+        try:
+            context = self._session.userdata
+        except Exception:
+            context = None
+
+        call = getattr(context, "call", None)
+        current_agent_config = getattr(context, "current_agent_config", None)
+        agent_config = getattr(context, "agent_config", None)
+        return {
+            "call_id": getattr(call, "call_id", None),
+            "organization_id": getattr(call, "organization_id", None),
+            "agent_id": getattr(current_agent_config, "uid", None)
+            or getattr(agent_config, "uid", None),
+        }
 
     def _fallback_to_vad_interruption(self) -> None:
         """Degrade gracefully from adaptive interruption to VAD-based interruption.

--- a/livekit-agents/tests/test_fork_wireup.py
+++ b/livekit-agents/tests/test_fork_wireup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 import time
 from types import SimpleNamespace
 
@@ -34,6 +35,64 @@ def _activity(opts: SimpleNamespace) -> AgentActivity:
     activity._opts = opts
     activity._dynamic_interruption = DynamicInterruptionManager(opts)
     return activity
+
+
+class _DiagnosticSpeech:
+    id = "speech-test"
+    _generation_id = "speech-test_1"
+    allow_interruptions = True
+
+    def __init__(self) -> None:
+        self.interrupted = False
+
+    def interrupt(self) -> _DiagnosticSpeech:
+        self.interrupted = True
+        return self
+
+
+def _diagnostic_activity(
+    *,
+    transcript: str,
+    ignore_words: list[str] | None = None,
+    min_words: int = 0,
+) -> tuple[AgentActivity, _DiagnosticSpeech]:
+    opts = SimpleNamespace(
+        interruption={"min_words": min_words},
+        interruption_ignore_words=ignore_words or [],
+        enable_dynamic_interruption=False,
+        enable_adaptive_endpointing=False,
+    )
+    speech = _DiagnosticSpeech()
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._opts = opts
+    activity._agent = SimpleNamespace(stt=object(), llm=None)
+    activity._session = SimpleNamespace(
+        options=opts,
+        stt=None,
+        llm=None,
+        agent_state="speaking",
+        _aec_warmup_remaining=0,
+        _aec_warmup_timer=None,
+        userdata=SimpleNamespace(
+            call=SimpleNamespace(call_id="call-1", organization_id="org-1"),
+            current_agent_config=SimpleNamespace(uid="agent-1"),
+        ),
+    )
+    activity._audio_recognition = SimpleNamespace(
+        current_transcript=transcript,
+        _endpointing=SimpleNamespace(overlapping=False),
+        on_start_of_speech=lambda **kwargs: None,
+        on_end_of_agent_speech=lambda **kwargs: None,
+    )
+    activity._interruption_by_audio_activity_enabled = True
+    activity._current_speech = speech
+    activity._paused_speech = None
+    activity._false_interruption_timer = None
+    activity._rt_session = None
+    activity._barge_in_source_event_keys = set()
+    activity._pause_enabled = lambda: False
+    activity._record_dynamic_continuation_collision = lambda: None
+    return activity, speech
 
 
 def _audio_recognition(opts: SimpleNamespace, multiplier: float) -> AudioRecognition:
@@ -125,6 +184,53 @@ def test_dynamic_interruption_enabled_consults_continuity_threshold() -> None:
     activity._dynamic_interruption.conversation_state.last_user_speech_end_time = time.time() - 3.0
     activity._capture_dynamic_continuity_at_speech_start()
     assert activity._get_dynamic_min_interruption_words() == 2
+
+
+def test_barge_in_source_candidate_logs_before_ignore_gate(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    activity, speech = _diagnostic_activity(transcript="네", ignore_words=["네"])
+    caplog.set_level(logging.INFO, logger="livekit.agents")
+
+    activity._interrupt_by_audio_activity(source="interim", text_hint="네")
+
+    assert speech.interrupted is False
+    candidate_records = [
+        record for record in caplog.records if record.message == "barge_in_source_candidate"
+    ]
+    commit_records = [
+        record for record in caplog.records if record.message == "barge_in_source_commit"
+    ]
+    assert len(candidate_records) == 1
+    assert candidate_records[0].source == "main_stt_interim"
+    assert candidate_records[0].candidate_result == "interruption_ignore_words"
+    assert candidate_records[0].ignore_match is True
+    assert candidate_records[0].call_id == "call-1"
+    assert commit_records == []
+
+
+def test_barge_in_source_commit_logs_once_for_eligible_candidate(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    activity, speech = _diagnostic_activity(transcript="예약 변경", ignore_words=["네"])
+    caplog.set_level(logging.INFO, logger="livekit.agents")
+
+    activity._interrupt_by_audio_activity(source="interim", text_hint="예약 변경")
+    activity._interrupt_by_audio_activity(source="interim", text_hint="예약 변경 다시")
+
+    assert speech.interrupted is True
+    candidate_records = [
+        record for record in caplog.records if record.message == "barge_in_source_candidate"
+    ]
+    commit_records = [
+        record for record in caplog.records if record.message == "barge_in_source_commit"
+    ]
+    assert len(candidate_records) == 1
+    assert len(commit_records) == 1
+    assert candidate_records[0].source == "main_stt_interim"
+    assert candidate_records[0].candidate_result == "candidate"
+    assert commit_records[0].source == "main_stt_interim"
+    assert commit_records[0].reason == "interrupt_current_speech"
 
 
 def test_adaptive_endpointing_disabled_no_multiplier() -> None:

--- a/livekit-agents/tests/test_fork_wireup.py
+++ b/livekit-agents/tests/test_fork_wireup.py
@@ -236,8 +236,8 @@ def test_barge_in_source_commit_logs_once_for_eligible_candidate(
 def test_barge_in_source_sink_receives_candidate_and_commit() -> None:
     activity, _speech = _diagnostic_activity(transcript="예약 변경", ignore_words=["네"])
     seen: list[tuple[object, str, dict[str, object]]] = []
-    activity._session.userdata.barge_in_source_event_sink = (
-        lambda session, *, event, metadata: seen.append((session, event, metadata))
+    activity._session.userdata.barge_in_source_event_sink = lambda session, *, event, metadata: (
+        seen.append((session, event, metadata))
     )
 
     activity._interrupt_by_audio_activity(source="interim", text_hint="예약 변경")
@@ -255,18 +255,16 @@ def test_barge_in_source_sink_failure_does_not_block_logging(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     activity, speech = _diagnostic_activity(transcript="예약 변경", ignore_words=["네"])
-    activity._session.userdata.barge_in_source_event_sink = (
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
-    )
+    activity._session.userdata.barge_in_source_event_sink = lambda *args, **kwargs: (
+        _ for _ in ()
+    ).throw(RuntimeError("boom"))
     caplog.set_level(logging.INFO, logger="livekit.agents")
 
     activity._interrupt_by_audio_activity(source="interim", text_hint="예약 변경")
 
     assert speech.interrupted is True
     assert [
-        record.message
-        for record in caplog.records
-        if record.message.startswith("barge_in_source_")
+        record.message for record in caplog.records if record.message.startswith("barge_in_source_")
     ] == ["barge_in_source_candidate", "barge_in_source_commit"]
 
 

--- a/livekit-agents/tests/test_fork_wireup.py
+++ b/livekit-agents/tests/test_fork_wireup.py
@@ -233,6 +233,43 @@ def test_barge_in_source_commit_logs_once_for_eligible_candidate(
     assert commit_records[0].reason == "interrupt_current_speech"
 
 
+def test_barge_in_source_sink_receives_candidate_and_commit() -> None:
+    activity, _speech = _diagnostic_activity(transcript="예약 변경", ignore_words=["네"])
+    seen: list[tuple[object, str, dict[str, object]]] = []
+    activity._session.userdata.barge_in_source_event_sink = (
+        lambda session, *, event, metadata: seen.append((session, event, metadata))
+    )
+
+    activity._interrupt_by_audio_activity(source="interim", text_hint="예약 변경")
+
+    assert [(event, metadata["source"]) for _, event, metadata in seen] == [
+        ("barge_in_source_candidate", "main_stt_interim"),
+        ("barge_in_source_commit", "main_stt_interim"),
+    ]
+    assert all(session is activity._session for session, _, _ in seen)
+    assert seen[0][2]["call_id"] == "call-1"
+    assert seen[1][2]["reason"] == "interrupt_current_speech"
+
+
+def test_barge_in_source_sink_failure_does_not_block_logging(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    activity, speech = _diagnostic_activity(transcript="예약 변경", ignore_words=["네"])
+    activity._session.userdata.barge_in_source_event_sink = (
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    caplog.set_level(logging.INFO, logger="livekit.agents")
+
+    activity._interrupt_by_audio_activity(source="interim", text_hint="예약 변경")
+
+    assert speech.interrupted is True
+    assert [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("barge_in_source_")
+    ] == ["barge_in_source_candidate", "barge_in_source_commit"]
+
+
 def test_adaptive_endpointing_disabled_no_multiplier() -> None:
     audio_recognition = _audio_recognition(
         _opts(enable_adaptive_endpointing=False),

--- a/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
+++ b/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
@@ -41,7 +41,7 @@ from livekit.agents.voice.avatar import (
 from .log import logger
 
 if TYPE_CHECKING:
-    from bithuman import AsyncBithuman  # type: ignore
+    from bithuman import AsyncBithuman
 
 _logger.remove()
 _logger.add(sys.stdout, level="INFO")


### PR DESCRIPTION
## 요약

- 기존 `barge_in_source_*` textPayload 진단 로그는 그대로 유지합니다.
- `session.userdata.barge_in_source_event_sink`가 callable이면 LiveKit이 source candidate/commit/false_interrupt metadata를 agent-server로 넘길 수 있게 했습니다.
- sink 예외는 debug 로그로만 삼키며, barge-in 판단/중단 동작에는 영향을 주지 않습니다.

현재 head: `4e175e1c155972c17bd90dbd8082c08a496659c9`

## 목적

agent-server에서 `emit_event()` 기반 `jsonPayload` 구조화 로그를 만들기 위한 최소 bridge입니다. LiveKit fork는 agent-server logging 모듈을 알지 않고, optional callback만 호출합니다.

## 안전성

- callback이 없으면 완전 no-op입니다.
- callback 실패는 기존 logging과 interruption flow를 막지 않습니다.
- metadata는 `dict(metadata)`로 복사해서 전달합니다.

## 검증

- `/tmp/codex-ruff-livekit/bin/ruff format --check livekit-agents/tests/test_fork_wireup.py`
  - 통과
- `/tmp/codex-ruff-livekit/bin/ruff check livekit-agents/tests/test_fork_wireup.py`
  - 통과
- `PYTHONPATH=livekit-agents /Users/ryanhan/Documents/development/voxai/vox-mono/domains/voxai/agent-server/.venv/bin/python -m pytest livekit-agents/tests/test_fork_wireup.py -k barge_in_source`
  - `4 passed, 13 deselected`
