### PR TITLE
fix(voice): ignored soft interruption 즉시 resume

### DIFF
--- a/livekit-agents/livekit/agents/tokenize/_basic_word.py
+++ b/livekit-agents/livekit/agents/tokenize/_basic_word.py
@@ -22,10 +22,12 @@ def split_words(
     words: list[tuple[str, int, int]] = []
 
     # CJK: \u4e00-\u9fff, \u3040-\u30ff, \u3400-\u4dbf
+    # Hangul: \uac00-\ud7a3
     # Thai: \u0E00-\u0E7F
     char_based_codes = (
         re.compile(
             r"[\u4e00-\u9fff\u3040-\u30ff\u3400-\u4dbf"  # CJK scripts
+            r"\uac00-\ud7a3"  # Hangul syllables
             r"\u0E00-\u0E7F]"  # Thai
         )
         if split_character

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -123,10 +123,6 @@ def _matches_ignore_words(text: str, ignore_words: list[str] | None) -> bool:
     if not cleaned_ignore_words:
         return False
 
-    # Single character: always ignore
-    if len(text_cleaned) == 1:
-        return True
-
     dp = [False] * (len(text_cleaned) + 1)
     dp[0] = True
     for i in range(1, len(text_cleaned) + 1):
@@ -2126,6 +2122,16 @@ class AgentActivity(RecognitionHooks):
             "manual",
             "realtime_llm",
         ):
+            if self._resume_paused_speech_if_ignored_transcript(
+                ev.alternatives[0].text,
+                source=(
+                    "preflight_ignore"
+                    if ev.type == stt.SpeechEventType.PREFLIGHT_TRANSCRIPT
+                    else "interim_ignore"
+                ),
+            ):
+                return
+
             self._interrupt_by_audio_activity(
                 source=(
                     "preflight"
@@ -2165,6 +2171,12 @@ class AgentActivity(RecognitionHooks):
             "manual",
             "realtime_llm",
         ):
+            if self._resume_paused_speech_if_ignored_transcript(
+                ev.alternatives[0].text,
+                source="final_ignore",
+            ):
+                return
+
             self._interrupt_by_audio_activity(
                 source="final",
                 text_hint=ev.alternatives[0].text,
@@ -3923,43 +3935,71 @@ class AgentActivity(RecognitionHooks):
             and self._session.output.audio.can_pause
         )
 
+    def _resume_paused_speech(self, *, source: str, timeout: float | None = None) -> bool:
+        if self._false_interruption_timer is not None:
+            self._false_interruption_timer.cancel()
+            self._false_interruption_timer = None
+
+        if self._paused_speech is None or (
+            self._current_speech and self._current_speech is not self._paused_speech.handle
+        ):
+            # already new speech is scheduled, do nothing
+            self._paused_speech = None
+            return False
+
+        resumed = False
+        if (
+            self._session.options.interruption["resume_false_interruption"]
+            and (audio_output := self._session.output.audio)
+            and audio_output.can_pause
+            and not self._paused_speech.handle.done()
+        ):
+            self._session._update_agent_state(
+                self._paused_speech.agent_state,
+                otel_context=self._paused_speech.handle._agent_turn_context,
+            )
+            if self._audio_recognition and self._paused_speech.agent_state == "speaking":
+                self._audio_recognition.on_start_of_agent_speech(started_at=time.time())
+            if self.interruption_enabled:
+                self._disable_vad_interruption_soon()
+            audio_output.resume()
+            resumed = True
+            logger.debug(
+                "resumed false interrupted speech",
+                extra={"timeout": timeout, "source": source},
+            )
+
+        self._session.emit("agent_false_interruption", AgentFalseInterruptionEvent(resumed=resumed))
+
+        self._paused_speech = None
+        return resumed
+
+    def _resume_paused_speech_if_ignored_transcript(self, text: str, *, source: str) -> bool:
+        opts = self._session.options
+        if (
+            not self._paused_speech
+            or not opts.interruption_ignore_words
+            or not text.strip()
+            or not _matches_ignore_words(text, opts.interruption_ignore_words)
+        ):
+            return False
+
+        logger.info(
+            "interruption_ignored_resume",
+            extra={
+                "source": source,
+                "event_text": _truncate_interruption_text(text),
+                "reason": "interruption_ignore_words",
+            },
+        )
+        return self._resume_paused_speech(source=source)
+
     def _start_false_interruption_timer(self, timeout: float) -> None:
         if self._false_interruption_timer is not None:
             self._false_interruption_timer.cancel()
 
         def _on_false_interruption() -> None:
-            if self._paused_speech is None or (
-                self._current_speech and self._current_speech is not self._paused_speech.handle
-            ):
-                # already new speech is scheduled, do nothing
-                self._paused_speech = None
-                return
-
-            resumed = False
-            if (
-                self._session.options.interruption["resume_false_interruption"]
-                and (audio_output := self._session.output.audio)
-                and audio_output.can_pause
-                and not self._paused_speech.handle.done()
-            ):
-                self._session._update_agent_state(
-                    self._paused_speech.agent_state,
-                    otel_context=self._paused_speech.handle._agent_turn_context,
-                )
-                if self._audio_recognition and self._paused_speech.agent_state == "speaking":
-                    self._audio_recognition.on_start_of_agent_speech(started_at=time.time())
-                if self.interruption_enabled:
-                    self._disable_vad_interruption_soon()
-                audio_output.resume()
-                resumed = True
-                logger.debug("resumed false interrupted speech", extra={"timeout": timeout})
-
-            self._session.emit(
-                "agent_false_interruption", AgentFalseInterruptionEvent(resumed=resumed)
-            )
-
-            self._paused_speech = None
-            self._false_interruption_timer = None
+            self._resume_paused_speech(source="timer", timeout=timeout)
 
         self._false_interruption_timer = self._session._loop.call_later(
             timeout, _on_false_interruption

--- a/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
+++ b/livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py
@@ -41,7 +41,7 @@ from livekit.agents.voice.avatar import (
 from .log import logger
 
 if TYPE_CHECKING:
-    from bithuman import AsyncBithuman  # type: ignore
+    from bithuman import AsyncBithuman
 
 _logger.remove()
 _logger.add(sys.stdout, level="INFO")

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -22,7 +22,9 @@ from livekit.agents.llm import (
 )
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
 from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
+from livekit.agents.tokenize.basic import split_words
 from livekit.agents.utils import aio
+from livekit.agents.voice.agent_activity import _matches_ignore_words
 from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnInfo
 from livekit.agents.voice.endpointing import BaseEndpointing
 from livekit.agents.voice.events import FunctionToolsExecutedEvent
@@ -542,6 +544,66 @@ async def test_false_interruption_before_speaking_resumes() -> None:
     assert len(playback_finished_events) == 1
     assert playback_finished_events[0].interrupted is False
     check_timestamp(playback_finished_events[0].playback_position, 5.0, speed_factor=speed)
+
+
+async def test_ignore_word_resumes_paused_speech_before_false_timeout() -> None:
+    speed = 5.0
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Tell me a story.")
+    actions.add_llm("Here is a short reply.", ttft=0.05, duration=0.05)
+    actions.add_tts(5.0, ttfb=0.05, duration=0.05)
+    actions.add_user_speech(4.0, 4.6, "네", stt_delay=0.2)
+
+    session = create_session(
+        actions,
+        speed_factor=speed,
+        can_pause_audio=True,
+        extra_kwargs={"interruption_ignore_words": ["네", "예"]},
+        turn_handling={
+            "interruption": {
+                "min_words": 0,
+                "false_interruption_timeout": 5.0 / speed,
+            }
+        },
+    )
+    agent = MyAgent()
+
+    agent_state_events: list[AgentStateChangedEvent] = []
+    playback_finished_events: list[PlaybackFinishedEvent] = []
+    false_interruption_events: list[AgentFalseInterruptionEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+    session.on("agent_false_interruption", false_interruption_events.append)
+    session.output.audio.on("playback_finished", playback_finished_events.append)
+
+    t_origin = await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    resumed_events = [ev for ev in false_interruption_events if ev.resumed]
+    assert resumed_events
+    # VAD pauses at ~4.5s, the interim "네" arrives at ~4.7s. If this waited
+    # for the false-interruption timer, it would resume around 9.6s instead.
+    check_timestamp(resumed_events[0].created_at - t_origin, 4.7, speed_factor=speed)
+
+    transitions = [(ev.old_state, ev.new_state) for ev in agent_state_events]
+    assert ("speaking", "listening") in transitions
+    assert ("listening", "speaking") in transitions
+    assert len(playback_finished_events) == 1
+    assert playback_finished_events[0].interrupted is False
+    check_timestamp(playback_finished_events[0].playback_position, 5.0, speed_factor=speed)
+
+
+def test_ignore_words_do_not_match_arbitrary_single_character() -> None:
+    assert _matches_ignore_words("네", ["네", "예"]) is True
+    assert _matches_ignore_words("왜", ["네", "예"]) is False
+
+
+def test_hangul_split_character_counts_syllables() -> None:
+    assert [word for word, _, _ in split_words("안녕하세요", split_character=True)] == [
+        "안",
+        "녕",
+        "하",
+        "세",
+        "요",
+    ]
 
 
 async def test_generate_reply() -> None:


### PR DESCRIPTION
## 요약
- VAD soft-pause 이후 STT interim/final이 ignore word로 확인되면 false-interruption timeout을 기다리지 않고 즉시 resume합니다.
- 기존 timer resume 로직을 `_resume_paused_speech()`로 분리해 timer와 ignored transcript resume이 같은 복구 경로를 타게 했습니다.
- Korean `min_words` 판정을 위해 Hangul syllable을 `split_character=True` tokenizer 범위에 포함했습니다.
- `_matches_ignore_words()`의 "한 글자면 무조건 ignore" 동작을 제거해 `왜` 같은 임의 한 글자 takeover가 ignore 처리되지 않도록 했습니다.
- CI에서 드러난 기존 bithuman plugin의 stale `type: ignore`를 제거했습니다. 런타임 동작 변경은 없고 type-check unblock 용도입니다.

## 배경
fast barge-in dev test에서 `min_words=0`을 쓰면 VAD가 STT보다 먼저 AI 출력을 pause할 수 있습니다. 이때 사용자가 `네/음` 같은 backchannel만 말한 경우 기존 구현은 false-interruption timer까지 기다려야 했고, 이것이 불필요한 pause를 만들 수 있었습니다.

이 PR은 모델/추론 경로를 새로 붙이지 않고, 이미 존재하는 pause/resume 경로 안에서 가장 작은 변경으로 `VAD fast pause + ignore word immediate resume` 계약을 만듭니다.

## 검증
- `PYTHONPATH="$PWD/livekit-agents:$PWD" /Users/ryanhan/Documents/development/voxai/vox-mono/infra/livekit-agents/.venv/bin/python -m pytest tests/test_agent_session.py -k "interruption or ignore or hangul_split_character" livekit-agents/tests/test_prod1419_backchannel_latency.py livekit-agents/tests/test_fork_wireup.py`
  - 18 passed, 39 deselected
- `PYTHONPATH="$PWD/livekit-agents:$PWD" /Users/ryanhan/Documents/development/voxai/vox-mono/infra/livekit-agents/.venv/bin/python -m ruff check livekit-agents/livekit/agents/voice/agent_activity.py livekit-agents/livekit/agents/tokenize/_basic_word.py livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py tests/test_agent_session.py`
- `PYTHONPATH="$PWD/livekit-agents:$PWD" /Users/ryanhan/Documents/development/voxai/vox-mono/infra/livekit-agents/.venv/bin/python -m ruff format --check livekit-agents/livekit/agents/voice/agent_activity.py livekit-agents/livekit/agents/tokenize/_basic_word.py livekit-plugins/livekit-plugins-bithuman/livekit/plugins/bithuman/avatar.py tests/test_agent_session.py`
