### PR TITLE
feat(voice): port dynamic interruption module onto 1.5.19.rc1

### DIFF
--- a/livekit-agents/livekit/agents/voice/dynamic_interruption.py
+++ b/livekit-agents/livekit/agents/voice/dynamic_interruption.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ..log import logger
+
+if TYPE_CHECKING:
+    from .agent_session import AgentSessionOptions
+
+
+def _get_min_interruption_words(opts: AgentSessionOptions) -> int:
+    interruption = getattr(opts, "interruption", None)
+    if isinstance(interruption, dict):
+        return int(interruption.get("min_words", 0) or 0)
+
+    return int(getattr(opts, "min_interruption_words", 0) or 0)
+
+
+@dataclass
+class ConversationStateTracker:
+    last_user_speech_end_time: float | None = None
+    continuation_collisions: int = 0
+
+
+class DynamicInterruptionManager:
+    def __init__(self, opts: AgentSessionOptions) -> None:
+        self._opts = opts
+        self.conversation_state = ConversationStateTracker()
+        self._collision_recorded_since_last_user_end = False
+        self._current_speech_within_continuity = False
+
+    # ---- Interruption dynamics ----
+    def on_agent_speech_started(self) -> None:
+        # Today no-op; reserved for future heuristics (e.g., decay collisions on speak)
+        pass
+
+    def on_user_speech_started(self, *, threshold: float | None = None) -> None:
+        if not getattr(self._opts, "enable_dynamic_interruption", False):
+            self._current_speech_within_continuity = False
+            return
+
+        last = self.conversation_state.last_user_speech_end_time
+        if last is None:
+            self._current_speech_within_continuity = False
+            return
+
+        if threshold is None:
+            threshold = float(getattr(self._opts, "conversation_continuity_threshold", 8.0) or 8.0)
+        self._current_speech_within_continuity = (time.time() - last) <= threshold
+
+    def on_user_speech_ended(self) -> None:
+        self.conversation_state.last_user_speech_end_time = time.time()
+        self._collision_recorded_since_last_user_end = False
+        # Prevent "just-ended current speech" from being treated as continuity.
+        self._current_speech_within_continuity = False
+
+    def get_current_min_interruption_words(self) -> int:
+        """Compute an adaptive min_interruption_words threshold.
+
+        Rationale:
+        - If the user's speech resumes within a short continuity window, allow
+          instant interruption by returning 0 words requirement.
+        - Otherwise, require at least 1 word (or the configured static minimum
+          if larger).
+        """
+        base_min = _get_min_interruption_words(self._opts)
+
+        if not getattr(self._opts, "enable_dynamic_interruption", False):
+            return base_min
+
+        last = self.conversation_state.last_user_speech_end_time
+        if last is None:
+            return base_min
+
+        # Continuity is determined when user speech starts, not after it ends.
+        if self._current_speech_within_continuity:
+            return 0
+
+        return max(1, base_min)
+
+    # ---- Endpointing dynamics ----
+    @property
+    def adaptive_endpointing_enabled(self) -> bool:
+        return bool(getattr(self._opts, "enable_adaptive_endpointing", False))
+
+    def record_continuation_collision(self) -> None:
+        if self._collision_recorded_since_last_user_end:
+            return
+        self._collision_recorded_since_last_user_end = True
+        self.conversation_state.continuation_collisions += 1
+        logger.info(
+            "Continuation collision detected (collision count: %s)",
+            self.conversation_state.continuation_collisions,
+        )
+
+    def get_endpointing_multiplier(self) -> float:
+        """Return a backoff multiplier based on recent collisions.
+
+        A simple capped linear backoff: 1.0 + 0.5 per collision, up to +1.5x.
+        """
+        if not self.adaptive_endpointing_enabled:
+            return 1.0
+
+        collisions = int(self.conversation_state.continuation_collisions)
+        if collisions <= 0:
+            return 1.0
+
+        return 1.0 + min(collisions, 3) * 0.5
+
+    def reset_collisions(self) -> None:
+        self.conversation_state.continuation_collisions = 0
+        self._collision_recorded_since_last_user_end = False


### PR DESCRIPTION
Adds the fork's `voice/dynamic_interruption.py` helper onto `fork-1.5.19.rc1`.

New standalone module (no upstream equivalent); depends only on stdlib + `..log`. Its callers in `audio_recognition.py` / `agent_activity.py` are wired in the separately-ported voice-pipeline changes, so this lands as an additive, import-safe module. Part of the 1.5.9 -> 1.5.19.rc1 fork re-port.
