### PR TITLE
fix(voice): default backchannel_boundary to None on 1.5.19.rc1

### DIFF
--- a/livekit-agents/livekit/agents/voice/turn.py
+++ b/livekit-agents/livekit/agents/voice/turn.py
@@ -110,8 +110,8 @@ class InterruptionOptions(TypedDict, total=False):
     speech classified as a backchannel by the adaptive detector is suppressed
     (events flagged as interruptions still pass through). Use a tuple to apply
     different values for start and end separately. ``None`` disables. Defaults
-    to ``(1.0, 1.0)``. End value accounts for STT transcript timestamp
-    inaccuracy."""
+    to ``None`` (1.4.6-compatible). End value accounts for STT transcript
+    timestamp inaccuracy."""
 
 
 _INTERRUPTION_DEFAULTS: InterruptionOptions = {
@@ -121,7 +121,7 @@ _INTERRUPTION_DEFAULTS: InterruptionOptions = {
     "min_words": 0,
     "resume_false_interruption": True,
     "false_interruption_timeout": 2.0,
-    "backchannel_boundary": (1.0, 1.0),
+    "backchannel_boundary": None,
 }
 
 


### PR DESCRIPTION
Bakes the interruption `backchannel_boundary` default to `None` on `fork-1.5.19.rc1` (1.4.6-compatible behavior) instead of upstream's `(1.0, 1.0)`.

No environment toggle is introduced — the default is fixed in the interruption defaults. `_resolve_interruption` continues to honor an explicit per-session override. Part of the 1.5.9 -> 1.5.19.rc1 fork re-port.
