### PR TITLE
feat(metrics): port extended metrics classes + tts tweak onto 1.5.19.rc1

### DIFF
--- a/livekit-agents/livekit/agents/metrics/__init__.py
+++ b/livekit-agents/livekit/agents/metrics/__init__.py
@@ -1,10 +1,13 @@
 from .base import (
+    AgentLLMMetrics,
     AgentMetrics,
     EOUMetrics,
     InterruptionMetrics,
     LLMMetrics,
     RealtimeModelMetrics,
+    ResponseLatencyMetrics,
     STTMetrics,
+    ToolExecutionMetrics,
     TTSMetrics,
     VADMetrics,
 )
@@ -29,6 +32,10 @@ __all__ = [
     "TTSMetrics",
     "RealtimeModelMetrics",
     "InterruptionMetrics",
+    # voxai custom extended metrics
+    "AgentLLMMetrics",
+    "ResponseLatencyMetrics",
+    "ToolExecutionMetrics",
     # New model usage classes
     "LLMModelUsage",
     "TTSModelUsage",

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Metadata(BaseModel):
@@ -193,6 +193,38 @@ class AvatarMetrics(_BaseMetrics):
     metadata: Metadata | None = None
 
 
+# --- voxai custom: Extended metrics for adaptive endpointing & tooling visibility ---
+
+
+class ResponseLatencyMetrics(_BaseMetrics):
+    type: Literal["response_latency_metrics"] = "response_latency_metrics"
+    timestamp: float
+    speech_id: str | None = None
+    e2e_latency: float
+    eou_timestamp: float
+    first_audio_timestamp: float
+    metadata: Metadata | None = None
+
+
+class AgentLLMMetrics(_BaseMetrics):
+    type: Literal["agent_llm_metrics"] = "agent_llm_metrics"
+    timestamp: float
+    speech_id: str | None = None
+    agent_ttft: float | None = None
+    llm_node_await: float | None = None
+    request_id: str | None = None
+    metadata: Metadata | None = None
+
+
+class ToolExecutionMetrics(_BaseMetrics):
+    type: Literal["tool_execution_metrics"] = "tool_execution_metrics"
+    timestamp: float
+    speech_id: str | None = None
+    total_execution_time: float
+    tool_durations: dict[str, float] = Field(default_factory=dict)
+    metadata: Metadata | None = None
+
+
 AgentMetrics = (
     STTMetrics
     | LLMMetrics
@@ -202,4 +234,7 @@ AgentMetrics = (
     | RealtimeModelMetrics
     | InterruptionMetrics
     | AvatarMetrics
+    | ResponseLatencyMetrics
+    | AgentLLMMetrics
+    | ToolExecutionMetrics
 )

--- a/livekit-agents/livekit/agents/metrics/utils.py
+++ b/livekit-agents/livekit/agents/metrics/utils.py
@@ -4,13 +4,16 @@ import logging
 
 from ..log import logger as default_logger
 from .base import (
+    AgentLLMMetrics,
     AgentMetrics,
     AvatarMetrics,
     EOUMetrics,
     InterruptionMetrics,
     LLMMetrics,
     RealtimeModelMetrics,
+    ResponseLatencyMetrics,
     STTMetrics,
+    ToolExecutionMetrics,
     TTSMetrics,
 )
 
@@ -19,7 +22,7 @@ def log_metrics(metrics: AgentMetrics, *, logger: logging.Logger | None = None) 
     if logger is None:
         logger = default_logger
 
-    metadata: dict[str, str | float] = {}
+    metadata: dict[str, object] = {}
     if metrics.metadata:
         metadata |= {
             "model_name": metrics.metadata.model_name or "unknown",
@@ -82,6 +85,44 @@ def log_metrics(metrics: AgentMetrics, *, logger: logging.Logger | None = None) 
             | {
                 "end_of_utterance_delay": round(metrics.end_of_utterance_delay, 2),
                 "transcription_delay": round(metrics.transcription_delay, 2),
+            },
+        )
+    elif isinstance(metrics, ResponseLatencyMetrics):
+        logger.info(
+            "Response latency metrics",
+            extra=metadata
+            | {
+                "speech_id": metrics.speech_id or "",
+                "e2e_latency": round(metrics.e2e_latency, 2),
+                "eou_timestamp": metrics.eou_timestamp,
+                "first_audio_timestamp": metrics.first_audio_timestamp,
+            },
+        )
+    elif isinstance(metrics, AgentLLMMetrics):
+        logger.info(
+            "Agent LLM metrics",
+            extra=metadata
+            | {
+                "speech_id": metrics.speech_id or "",
+                "agent_ttft": round(metrics.agent_ttft, 2)
+                if metrics.agent_ttft is not None
+                else None,
+                "llm_node_await": round(metrics.llm_node_await, 2)
+                if metrics.llm_node_await is not None
+                else None,
+                "request_id": metrics.request_id or "",
+            },
+        )
+    elif isinstance(metrics, ToolExecutionMetrics):
+        logger.info(
+            "Tool execution metrics",
+            extra=metadata
+            | {
+                "speech_id": metrics.speech_id or "",
+                "total_execution_time": round(metrics.total_execution_time, 2),
+                "tool_durations": {
+                    name: round(duration, 2) for name, duration in metrics.tool_durations.items()
+                },
             },
         )
     elif isinstance(metrics, STTMetrics):

--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -759,7 +759,7 @@ class AudioEmitter:
         sample_rate: int,
         num_channels: int,
         mime_type: str,
-        frame_size_ms: int = 200,
+        frame_size_ms: int = 50,  # voxai: reduced from 200 to 50 for lower TTFB
         stream: bool = False,
     ) -> None:
         if self._started:


### PR DESCRIPTION
Re-applies the fork's metrics customizations onto the `fork-1.5.19.rc1` integration branch (based on upstream `livekit-agents@1.5.19.rc1`).

- `metrics/base.py`: add `AgentLLMMetrics`, `ResponseLatencyMetrics`, `ToolExecutionMetrics` (upstream 1.5.19.rc1 additions to this file are preserved)
- `metrics/utils.py`: supporting helpers
- `metrics/__init__.py`: export the new classes
- `tts/tts.py`: minor tweak

Source-only; tests are ported separately with the voice-pipeline changes. Part of the upstream 1.5.9 -> 1.5.19.rc1 fork re-port.
