### PR TITLE
feat(observability): worker drain-stage 진단 로깅 재포팅 (1.5.19.rc1)

### DIFF
--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -878,21 +878,94 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             if self._draining:
                 return
 
+            def _msg_chan_state() -> dict[str, int | bool | None]:
+                msg_chan = getattr(self, "_msg_chan", None)
+                if msg_chan is None:
+                    return {"msg_qsize": None, "msg_full": None}
+
+                return {"msg_qsize": msg_chan.qsize(), "msg_full": msg_chan.full()}
+
+            def _proc_logging_extra(proc: ipc.job_executor.JobExecutor) -> dict[str, Any]:
+                try:
+                    return proc.logging_extra()
+                except AttributeError:
+                    return {}
+
+            def _running_job_id(proc: ipc.job_executor.JobExecutor) -> str | None:
+                running_job = proc.running_job
+                job = getattr(running_job, "job", None)
+                return getattr(job, "id", None)
+
             logger.info("draining worker", extra={"id": self.id, "timeout": timeout})
             self._draining = True
+            logger.debug(
+                "drain stage",
+                extra={
+                    "id": self.id,
+                    "stage": "update_worker_status_start",
+                    **_msg_chan_state(),
+                },
+            )
             await self._update_worker_status()
+            logger.debug(
+                "drain stage",
+                extra={
+                    "id": self.id,
+                    "stage": "update_worker_status_done",
+                    **_msg_chan_state(),
+                },
+            )
 
             async def _drain() -> None:
                 # wait for in-flight availability tasks to finish launching their jobs
+                pending_tasks = [t for t in self._job_lifecycle_tasks if not t.done()]
+                logger.debug(
+                    "drain stage",
+                    extra={
+                        "id": self.id,
+                        "stage": "job_lifecycle_tasks_start",
+                        "pending_count": len(pending_tasks),
+                        "pending_tasks": [t.get_name() for t in pending_tasks],
+                    },
+                )
                 await asyncio.gather(*self._job_lifecycle_tasks, return_exceptions=True)
+                logger.debug(
+                    "drain stage",
+                    extra={"id": self.id, "stage": "job_lifecycle_tasks_done"},
+                )
 
                 # then wait for the launched jobs to complete
                 while True:
                     procs = [p for p in self._proc_pool.processes if p.running_job]
+                    logger.debug(
+                        "drain stage",
+                        extra={
+                            "id": self.id,
+                            "stage": "proc_scan",
+                            "running_proc_count": len(procs),
+                            "running_job_ids": [_running_job_id(p) for p in procs],
+                        },
+                    )
                     if not procs:
                         break
                     for proc in procs:
+                        logger.debug(
+                            "drain stage",
+                            extra={
+                                "id": self.id,
+                                "stage": "proc_join_start",
+                                **_proc_logging_extra(proc),
+                            },
+                        )
                         await proc.join()
+                        logger.debug(
+                            "drain stage",
+                            extra={
+                                "id": self.id,
+                                "stage": "proc_join_done",
+                                **_proc_logging_extra(proc),
+                            },
+                        )
 
             if timeout:
                 await asyncio.wait_for(_drain(), timeout)  # raises asyncio.TimeoutError on timeout
@@ -1007,7 +1080,30 @@ class AgentServer(utils.EventEmitter[EventTypes]):
             elif which == "ping":
                 return
 
+        which = msg.WhichOneof("message")
+        if self._draining or self._msg_chan.full():
+            logger.debug(
+                "worker message queue send start",
+                extra={
+                    "id": self.id,
+                    "msg_type": which,
+                    "msg_qsize": self._msg_chan.qsize(),
+                    "msg_full": self._msg_chan.full(),
+                    "draining": self._draining,
+                },
+            )
         await self._msg_chan.send(msg)
+        if self._draining or self._msg_chan.full():
+            logger.debug(
+                "worker message queue send done",
+                extra={
+                    "id": self.id,
+                    "msg_type": which,
+                    "msg_qsize": self._msg_chan.qsize(),
+                    "msg_full": self._msg_chan.full(),
+                    "draining": self._draining,
+                },
+            )
 
     @utils.log_exceptions(logger=logger)
     async def _connection_task(self) -> None:


### PR DESCRIPTION
## 무엇을 / 왜

production fork(`2679eef3a`)에 있던 **worker drain 단계별 진단 로깅**이 1.5.19.rc1 재포팅 중 누락됐습니다(adversarial codex review에서 발견, high). 이를 1.5.19.rc1 구조에 맞춰 복원합니다.

## 변경 (logging only)

`AgentServer.drain()` / `_drain()` / 메시지 큐 send 경로에 `logger.debug` trace 추가:
- helper: `_msg_chan_state` / `_proc_logging_extra` / `_running_job_id`
- 단계: `update_worker_status_start/done` · `job_lifecycle_tasks_start/done`(pending task 이름) · `proc_scan`(running job ids) · `proc_join_start/done`(proc extra) · send-path(draining/queue-full 시 큐 상태)

## 왜 필요한가
drain timeout / **terminating-pod hang** 발생 시 "어떤 job/proc/큐에서 막혔는지"를 production 로그만으로 식별하기 위함. vox의 drain-wedge 인시던트 대응에 load-bearing.

## 안전성
- **순수 additive**(upstream 0줄 제거/변경), 전부 `logger.debug` → **동작 변화 0**.
- ruff clean · import OK · 변경 파일 mypy 0 error.

## 참조
- adversarial review finding [high] worker.py:881-899
- 원본 패치: `git diff ef9d8fbfa..2679eef3a -- worker.py`
