### PR TITLE
feat(observability): job-process shutdown trace 재포팅 (1.5.19.rc1)

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -365,6 +365,27 @@ class _JobProc:
 
         shutdown_info = await self._shutdown_fut
 
+        # voxai: shutdown trace logging (aclose diagnostics)
+        shutdown_trace_id = f"{id(self)}-{asyncio.get_running_loop().time():.6f}"
+
+        def _log_shutdown_stage(event: str, **extra: object) -> None:
+            fields = {
+                "trace_id": shutdown_trace_id,
+                "event": event,
+                "job_id": self._job_ctx.job.id,
+                **extra,
+            }
+            field_text = " ".join(
+                f"{key}={value!r}" for key, value in fields.items() if value is not None
+            )
+            logger.info("job_proc_shutdown_trace %s", field_text)
+
+        _log_shutdown_stage(
+            "shutdown_fut_resolved",
+            reason=shutdown_info.reason,
+            user_initiated=shutdown_info.user_initiated,
+        )
+
         # wait for the entrypoint to finish, cancel if it takes too long
         if not job_entry_task.done():
             try:
@@ -378,28 +399,39 @@ class _JobProc:
                 pass
 
         if session := self._job_ctx._primary_agent_session:
+            _log_shutdown_stage("session_aclose_start")
             try:
                 await asyncio.wait_for(session.aclose(), timeout=_SESSION_ACLOSE_TIMEOUT)
+                _log_shutdown_stage("session_aclose_done")
             except asyncio.TimeoutError:
+                _log_shutdown_stage("session_aclose_timeout", timeout=_SESSION_ACLOSE_TIMEOUT)
                 logger.error(
                     "AgentSession.aclose() timed out after %.1fs; "
                     "proceeding with shutdown so registered callbacks still run.",
                     _SESSION_ACLOSE_TIMEOUT,
                 )
+        else:
+            _log_shutdown_stage("session_aclose_skipped_no_primary_session")
 
         if self._session_end_fnc:
             try:
+                _log_shutdown_stage("session_end_callback_start")
                 await asyncio.wait_for(
                     self._session_end_fnc(self._job_ctx),
                     timeout=self._session_end_timeout,
                 )
+                _log_shutdown_stage("session_end_callback_done")
             except asyncio.TimeoutError:
+                _log_shutdown_stage("session_end_callback_timeout")
                 logger.error("on_session_end timed out after %ds", self._session_end_timeout)
             except Exception:
+                _log_shutdown_stage("session_end_callback_error")
                 logger.exception("error while executing the on_session_end callback")
 
+        _log_shutdown_stage("job_ctx_on_session_end_start")
         try:
             await self._job_ctx._on_session_end()
+            _log_shutdown_stage("job_ctx_on_session_end_done")
         except Exception:
             logger.exception("error in job_ctx._on_session_end")
 


### PR DESCRIPTION
## 무엇을 / 왜

production fork(`2679eef3a`)에 있던 **job process shutdown 단계별 trace**가 1.5.19.rc1 재포팅 중 누락됐습니다(adversarial codex review에서 발견, medium). 복원합니다.

## 변경 (logging only)

`_JobProc` 종료 시퀀스에 `job_proc_shutdown_trace`(`logger.info`) trace 추가:
- `shutdown_fut_resolved` · `session_aclose_start/done` · `session_end_callback_start/done/timeout/error` · `job_ctx_on_session_end_start/done`
- 각 trace에 `trace_id` + `job_id` + stage

## upstream 적응 (중요)
1.5.19.rc1은 `session.aclose()`를 **60s `wait_for`+try/except**로 감쌌습니다. 이 guardrail과 기존 timeout 에러 메시지를 **그대로 유지**하고, 그 timeout 경로에만 **`session_aclose_timeout` trace를 추가**했습니다. 즉 60s 안에서 어느 단계가 느리거나 막혔는지 trace_id로 식별 가능.

## 안전성
- **순수 additive**(upstream 0줄 제거/변경, 제어흐름·예외 의미 불변), 전부 로그 → **동작 변화 0**.
- ruff clean · import OK · 변경 파일 mypy 0 error.

## 참조
- adversarial review finding [medium] ipc/job_proc_lazy_main.py:380-388
- 원본 패치: `git diff ef9d8fbfa..2679eef3a -- ipc/job_proc_lazy_main.py`
