### PR TITLE
feat(observability): aclose가 '왜' cancel됐는지 job teardown trace

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -234,6 +234,11 @@ class _JobProc:
 
                     self._start_job(msg)
                 if isinstance(msg, ShutdownRequest):
+                    self._emit_shutdown_trace(
+                        "shutdown_request_received",
+                        reason=getattr(msg, "reason", None),
+                        has_running_job=self.has_running_job,
+                    )
                     await self._client.send(ShutdownRequestAck())
 
                     if not self.has_running_job:
@@ -256,13 +261,44 @@ class _JobProc:
             self._inf_client.close()
 
         read_task = asyncio.create_task(_read_ipc_task(), name="job_ipc_read")
+        teardown_via_cancel = False
         try:
             await self._exit_proc_flag.wait()
+        except asyncio.CancelledError:
+            teardown_via_cancel = True
+            raise
         finally:
             # ensure cleanup on cancellation (e.g. parent channel closes)
+            job_task = self._job_task
+            self._emit_shutdown_trace(
+                "main_task_teardown",
+                via_cancel=teardown_via_cancel,
+                exit_flag_set=self._exit_proc_flag.is_set(),
+                job_task_running=job_task is not None and not job_task.done(),
+            )
             if self._job_task is not None:
                 await aio.cancel_and_wait(self._job_task)
             await aio.cancel_and_wait(read_task)
+
+    def _emit_shutdown_trace(self, event: str, **extra: object) -> None:
+        # voxai: why-cancel observability for job teardown. Emitted from the IPC
+        # message loop and the main-task teardown (which force-cancels an
+        # in-flight job_task). Pairs with `_log_shutdown_stage` so a cancelled
+        # `session.aclose()` can be traced to its trigger: a parent
+        # ShutdownRequest vs a dropped IPC channel cancelling the main task
+        # mid-shutdown (via_cancel=True, job_task_running=True).
+        job_id = None
+        job_ctx = getattr(self, "_job_ctx", None)
+        if job_ctx is not None:
+            try:
+                job_id = job_ctx.job.id
+            except Exception:
+                job_id = None
+        fields = {"event": event, "job_id": job_id, **extra}
+        field_text = " ".join(
+            f"{key}={value!r}" for key, value in fields.items() if value is not None
+        )
+        logger.info("job_proc_shutdown_trace %s", field_text)
 
     def _start_job(self, msg: StartJobRequest) -> None:
         if msg.running_job.fake_job:

--- a/livekit-agents/livekit/agents/ipc/proc_client.py
+++ b/livekit-agents/livekit/agents/ipc/proc_client.py
@@ -124,7 +124,34 @@ class _ProcClient:
                 self._main_task_fnc(ipc_ch), name="main_task_entrypoint"
             )
 
-            def _done_cb(_: asyncio.Task[None]) -> None:
+            exit_trigger: str | None = None
+
+            def _done_cb(task: asyncio.Task[None]) -> None:
+                nonlocal exit_trigger
+                if exit_trigger is None:
+                    # voxai: name the *immediate* trigger of a job teardown. The
+                    # first of read_task / health_check_task / main_task to finish
+                    # ends this monitor loop; the subsequent cancel_and_wait then
+                    # force-cancels a still-running main_task (and thus an in-flight
+                    # session.aclose()). Which task fired first is the sender:
+                    #   ipc_read     -> parent IPC channel closed (EOF / dropped)
+                    #   health_check -> parent ping timed out (parent unresponsive)
+                    #   main_task_entrypoint -> job finished on its own (graceful)
+                    # Pairs with `main_task_teardown` in job_proc_lazy_main:
+                    # via_cancel=True there + ipc_read here = parent dropped the
+                    # channel mid-shutdown.
+                    _trigger_names = {
+                        "ipc_read": "ipc_channel_closed",
+                        "health_check": "ping_timeout",
+                        "main_task_entrypoint": "main_task_done",
+                    }
+                    exit_trigger = _trigger_names.get(task.get_name(), task.get_name())
+                    logger.info(
+                        "proc_client_monitor_exit trigger=%r main_task_running=%r",
+                        exit_trigger,
+                        not main_task.done(),
+                    )
+
                 with contextlib.suppress(asyncio.InvalidStateError):
                     exit_flag.set()
 

--- a/livekit-agents/livekit/agents/ipc/proc_pool.py
+++ b/livekit-agents/livekit/agents/ipc/proc_pool.py
@@ -174,6 +174,10 @@ class ProcPool(utils.EventEmitter[EventTypes]):
                 self.emit("process_job_launched", proc)
                 return
             except Exception:
+                logger.warning(
+                    "closing job process: launch failed",
+                    extra=proc.logging_extra(),
+                )
                 close_task = asyncio.create_task(proc.aclose())
                 self._close_tasks.add(close_task)
                 close_task.add_done_callback(self._close_tasks.discard)
@@ -291,6 +295,10 @@ class ProcPool(utils.EventEmitter[EventTypes]):
                 await asyncio.sleep(0.1)
         except asyncio.CancelledError:
             await aio.cancel_and_wait(*self._spawn_tasks)
+            logger.info(
+                "draining job process pool: closing %d process(es)",
+                len(self._executors),
+            )
             await asyncio.gather(*[proc.aclose() for proc in self._executors])
             await asyncio.gather(*self._close_tasks)
             await asyncio.gather(*self._monitor_tasks)

--- a/livekit-agents/livekit/agents/ipc/supervised_proc.py
+++ b/livekit-agents/livekit/agents/ipc/supervised_proc.py
@@ -308,6 +308,12 @@ class SupervisedProc(ABC):
             return
 
         self._closing = True
+        # voxai: who/why-cancel observability. Marks a parent-initiated graceful
+        # close of this job process (sends ShutdownRequest to the child). Pairs
+        # with the child's `shutdown_request_received` / `main_task_teardown`
+        # traces: absence of this line + child `via_cancel=True` means the close
+        # was NOT a graceful parent ShutdownRequest (IPC drop / kill instead).
+        logger.info("closing supervised job process", extra=self.logging_extra())
         with contextlib.suppress(duplex_unix.DuplexClosed):
             await channel.asend_message(self._pch, proto.ShutdownRequest())
 


### PR DESCRIPTION
## 무엇을 / 왜

정상 통화 종료 시 `session.aclose()`가 외부에서 cancel되면 뒤따르는 finalize(`session_end_fnc`)가 스킵되어 `calls.status`가 `ongoing`에 고착되는 고아콜이 발생합니다 (2026-06-24 `f616d2ec` RCA).

PR#34가 `session_aclose_start/done/timeout`까지는 보여주지만, **aclose가 누가/왜 cancel됐는지**는 안 보입니다. 이 PR은 child(무엇이/어느 경로) + parent(누가/왜) + 직접 트리거(무엇이 먼저 끊었나) 3계층을 trace로 남겨, 다음 동일 incident를 로그만으로 규명할 수 있게 합니다.

## 변경 (logging only, additive)

### child — `_JobProc` (job_proc_lazy_main.py)
- **`shutdown_request_received`** — 부모 `ShutdownRequest` 수신 시 (`reason`, `has_running_job`).
- **`main_task_teardown`** — run-loop `finally`(job_task를 cancel하기 직전): `via_cancel`, `exit_flag_set`, `job_task_running`.

### child — `_ProcClient._monitor_task` (proc_client.py)
- **`proc_client_monitor_exit`** — 모니터 루프를 끝낸 **첫 task**를 사유로 기록 (`trigger`, `main_task_running`). 이 직후 `cancel_and_wait`가 살아있는 main_task를 force-cancel하므로, 이게 force-cancel의 **직접 발신자**:
  - `ipc_channel_closed` — 부모 IPC 채널 닫힘(EOF/드롭)
  - `ping_timeout` — 부모 무응답(ping timeout)
  - `main_task_done` — job 자체 종료(graceful, force-cancel 아님)

### parent — `SupervisedProc` / `ProcPool` (supervised_proc.py, proc_pool.py)
- **`closing supervised job process`** — 부모가 graceful close(=ShutdownRequest 송신)할 때, job_id/pid와 함께.
- **`closing job process: launch failed`** / **`draining job process pool`** — proc_pool의 close 사유(누가/왜).
- (timeout kill 사유는 기존 `process did not ack/exit ... killing process` 로그가 이미 커버.)

## 판독 (누가/왜) — 이제 전 경로 sender 식별
| 관측 | 해석 (누가/뭐가 보냈나) |
|------|------|
| parent `closing supervised job process` + child `shutdown_request_received` (+reason) | **graceful close** — 부모 worker가 사유(launch failed / drain / ...)로 ShutdownRequest 송신 |
| child `proc_client_monitor_exit trigger=ipc_channel_closed` + `main_task_teardown via_cancel=True` + parent close 로그 **없음** | **부모 IPC 채널 드롭** mid-shutdown → in-flight aclose force-cancel (= 이번 고아 트리거) |
| child `proc_client_monitor_exit trigger=ping_timeout` | **부모 무응답**(hang/네트워크) → force-cancel |
| parent `process exited with non-zero exit code N` (기존, N<0=시그널) | **child 자체 크래시/시그널 사망** (예 -11=SIGSEGV) |
| parent `killing process` / `process is unresponsive` (기존) | kill-on-timeout / 무응답 kill |

`shutdown_trace_id`(PR#34)와 같은 job/pid 로그 스트림에서 시계열로 결합됩니다.

## 남는 한계 (정직)
직접 트리거(`ipc_channel_closed` / `ping_timeout` / crash)까지는 식별되지만, **부모 연결이 "왜" 끊겼나의 최상위 원인**(워커 SIGTERM, 서버측 disconnect, GKE 노드 drain 등)은 worker/server 레벨 신호가 추가로 필요합니다. 다만 이번 고아의 핵심 미지수였던 "graceful도 kill도 crash도 아닌 clean force-cancel"은 이제 `ipc_channel_closed` vs `ping_timeout`으로 **명시**됩니다.

## 안전성
- 순수 additive. child의 `except asyncio.CancelledError`는 플래그만 세우고 즉시 `raise` → 기존 finally 동작·예외 의미 불변.
- `proc_client` 변경은 done-callback에 로그 1회(첫 트리거만)만 추가 → 제어 흐름 불변.
- 시그니처/proto 변경 없음(Protocol `aclose` 불변) → mypy 영향 0. ruff format/lint clean.

## 참조
- RCA: `f616d2ec` 고아콜 (aclose cancel → finalize skip)
- 관련: PR#34 (`job_proc_shutdown_trace`), PROD-1288 / PROD-1351
