### PR TITLE
feat(ipc): forkserver preload에 __main__ 유지 + 자식 init 단계 로그

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
+++ b/livekit-agents/livekit/agents/ipc/job_proc_lazy_main.py
@@ -78,6 +78,11 @@ def proc_main(args: ProcStartArgs) -> None:
     log_handler = LogQueueHandler(log_cch)
     root_logger.addHandler(log_handler)
 
+    # voxai: parent's "initializing process" timestamp minus this one = child
+    # bootstrap (module import) time; the "process initialized" elapsed_time on
+    # the parent bundles bootstrap + prewarm, so this log lets us split them.
+    logger.debug("proc_main started")
+
     job_proc = _JobProc(
         args.initialize_process_fnc,
         args.job_entrypoint_fnc,
@@ -210,6 +215,8 @@ class _JobProc:
         return self._job_task is not None
 
     def initialize(self, init_req: InitializeRequest, client: _ProcClient) -> None:
+        import time
+
         self._client = client
         self._inf_client = _InfClient(client)
         self._job_proc = JobProcess(
@@ -217,7 +224,12 @@ class _JobProc:
             user_arguments=self._user_arguments,
             http_proxy=init_req.http_proxy or None,
         )
+        prewarm_start = time.perf_counter()
         self._initialize_process_fnc(self._job_proc)
+        logger.debug(
+            "user prewarm completed",
+            extra={"elapsed_time": round(time.perf_counter() - prewarm_start, 2)},
+        )
 
     @log_exceptions(logger=logger)
     async def entrypoint(self, cch: aio.ChanReceiver[Message]) -> None:

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -713,7 +713,15 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 )
 
             if self._mp_ctx_str == "forkserver":
-                plugin_packages = [p.package for p in Plugin.registered_plugins] + ["av"]
+                # voxai: set_forkserver_preload() REPLACES CPython's default preload
+                # list ['__main__'], so keep "__main__" here — the forkserver then
+                # imports the user's main module once and forked job processes
+                # inherit the whole import closure via COW instead of re-importing
+                # it on every spawn.
+                plugin_packages = [p.package for p in Plugin.registered_plugins] + [
+                    "av",
+                    "__main__",
+                ]
                 logger.info("preloading plugins", extra={"packages": plugin_packages})
                 self._mp_ctx.set_forkserver_preload(plugin_packages)
 


### PR DESCRIPTION
## 변경 내용

### worker.py — forkserver preload 목록에 `__main__` 추가
`set_forkserver_preload()`는 CPython 기본 preload 목록 `['__main__']`을 **교체**하므로, upstream livekit/agents#2238에서 플러그인 preload가 들어올 때 메인 모듈 preload가 의도치 않게 빠졌다. 그 결과 fork된 잡 프로세스마다 유저 메인 모듈의 전체 임포트 클로저를 스폰 시마다 재임포트한다. 임포트 트리가 무거운 앱은 스폰에 수 초를 내고, CPU 경합 시 `initialize_process_timeout`(10s)을 초과할 수 있다 (동일 실패 모드: upstream livekit/agents#5868).

`__main__`을 preload 목록에 유지하면 forkserver가 메인 모듈을 1회 임포트하고 자식들은 COW로 상속한다.

### job_proc_lazy_main.py — init 단계 분해 계측
부모 측 `process initialized` `elapsed_time`은 자식 부트스트랩(모듈 임포트) + 유저 prewarm의 합산이라 분해가 불가했다. 두 로그를 추가:
- `proc_main started` — 부모 `initializing process` 타임스탬프와의 차 = 부트스트랩(임포트) 시간
- `user prewarm completed` (`elapsed_time`) — 유저 `initialize_fnc` 소요

## 주의점
- 메인 모듈의 module-level 코드가 forkserver 프로세스에서 1회 실행된다. 임포트 시점에 스레드/gRPC 채널을 만드는 앱은 fork 안전성 확인 필요 (agent-server 측 대응은 별도 PR).
- `job_proc_lazy_main`은 preload에 넣지 않는다 — 임포트 시점의 `current_process().name == "job_proc"` 가드(시그널 핸들러 설치)가 forkserver에서 깨진다.

## 검증
- ruff format/check 통과
- dev 환경 canary로 `process initialized` elapsed_time 전후 비교 예정 (agent-server rev bump PR에서)

Ref: PROD-2089

🤖 Generated with [Claude Code](https://claude.com/claude-code)