### PR TITLE
feat(voice): Acoustic interruption 연결 장애 시 안전한 fallback 지원

### DIFF
--- a/livekit-agents/livekit/agents/inference/__init__.py
+++ b/livekit-agents/livekit/agents/inference/__init__.py
@@ -2,6 +2,8 @@ from .interruption import (
     AdaptiveInterruptionDetector,
     InterruptionDataFrameType,
     InterruptionDetectionError,
+    InterruptionDetectionStateChangedEvent,
+    InterruptionDetectorState,
     OverlappingSpeechEvent,
 )
 from .llm import LLM, LLMModels, LLMStream
@@ -18,6 +20,8 @@ __all__ = [
     "LLMModels",
     "AdaptiveInterruptionDetector",
     "InterruptionDetectionError",
+    "InterruptionDetectionStateChangedEvent",
+    "InterruptionDetectorState",
     "OverlappingSpeechEvent",
     "InterruptionDataFrameType",
 ]

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -1029,6 +1029,8 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
             interval = max(0.01, min(self._opts.inference_timeout / 2, 0.1))
             while True:
                 await asyncio.sleep(interval)
+                if closing_ws:
+                    return
                 now = perf_counter_ns()
                 for _key, entry in self._cache.items():
                     if entry.total_duration is not None:

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -524,6 +524,7 @@ class InterruptionStreamBase(ABC):
         self._sample_rate = self._opts.sample_rate
 
         self._overlap_started_at: float | None = None
+        self._overlap_request_boundary_ns: int | None = None
         self._user_speech_span: trace.Span | None = None
         self._agent_speech_started: bool = False
         self._overlap_started: bool = False
@@ -573,6 +574,7 @@ class InterruptionStreamBase(ABC):
                     self._cache.clear()
                     self._overlap_started = False
                     self._overlap_started_at = None
+                    self._overlap_request_boundary_ns = None
                     self._user_speech_span = None
                     await self._num_requests.set(0)
 
@@ -666,6 +668,7 @@ class InterruptionStreamBase(ABC):
         async def _reset_state() -> None:
             self._agent_speech_started = False
             self._overlap_started = False
+            self._overlap_request_boundary_ns = None
             self._overlap_count = 0
             self._accumulated_samples = 0
             await self._num_requests.set(0)
@@ -686,6 +689,7 @@ class InterruptionStreamBase(ABC):
                     continue
                 case _OverlapSpeechStartedSentinel() if self._agent_speech_started:
                     self._overlap_started_at = input_frame._started_at
+                    self._overlap_request_boundary_ns = perf_counter_ns()
                     self._user_speech_span = input_frame._user_speaking_span
                     self._overlap_started = True
                     self._accumulated_samples = 0
@@ -732,6 +736,7 @@ class InterruptionStreamBase(ABC):
                     self._overlap_started = False
                     self._accumulated_samples = 0
                     self._overlap_started_at = None
+                    self._overlap_request_boundary_ns = None
                     self._cache.clear()
                 case rtc.AudioFrame() if self._agent_speech_started:
                     samples_written = self._audio_buffer.push_frame(input_frame)
@@ -745,6 +750,13 @@ class InterruptionStreamBase(ABC):
     def send(self, event: OverlappingSpeechEvent) -> None:
         self._event_ch.send_nowait(event)
         self._model.emit(event.type, event)
+
+    def _is_current_overlap_request(self, created_at: int) -> bool:
+        return (
+            self._overlap_started
+            and self._overlap_request_boundary_ns is not None
+            and created_at >= self._overlap_request_boundary_ns
+        )
 
     @utils.log_exceptions(logger=logger)
     async def _metrics_monitor_task(
@@ -831,6 +843,8 @@ class InterruptionHttpStream(InterruptionStreamBase):
                     )
                     self.send(ev)
                     self._overlap_started = False
+                    self._overlap_request_boundary_ns = None
+                    self._cache.clear()
 
         data_ch = aio.Chan[npt.NDArray[np.int16]]()
         tasks = [
@@ -1091,18 +1105,19 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                     case InterruptionWSDetectedMessage():
                         created_at = msg.created_at
                         overlap_started_at = self._overlap_started_at
-                        if overlap_started_at is None or not self._overlap_started:
+                        if overlap_started_at is None or not self._is_current_overlap_request(
+                            created_at
+                        ):
                             continue
-                        entry = self._cache.update_value(
+                        entry = self._cache.set_or_update(
                             created_at,
+                            lambda c=created_at: InterruptionCacheEntry(created_at=c),  # type: ignore[misc]
                             total_duration=(perf_counter_ns() - created_at) / 1e9,
                             probabilities=np.array(msg.probabilities, dtype=np.float32),
                             is_interruption=True,
                             prediction_duration=msg.prediction_duration,
                             detection_delay=time.time() - overlap_started_at,
                         )
-                        if entry is None:
-                            continue
                         if self._user_speech_span:
                             self._update_user_speech_span(self._user_speech_span, entry)
                             self._user_speech_span = None
@@ -1124,21 +1139,24 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                         ev.num_requests = await self._num_requests.get_and_reset()
                         self.send(ev)
                         self._overlap_started = False
+                        self._overlap_request_boundary_ns = None
+                        self._cache.clear()
                     case InterruptionWSInferenceDoneMessage():
                         created_at = msg.created_at
                         overlap_started_at = self._overlap_started_at
-                        if overlap_started_at is None or not self._overlap_started:
+                        if overlap_started_at is None or not self._is_current_overlap_request(
+                            created_at
+                        ):
                             continue
-                        entry = self._cache.update_value(
+                        entry = self._cache.set_or_update(
                             created_at,
+                            lambda c=created_at: InterruptionCacheEntry(created_at=c),  # type: ignore[misc]
                             total_duration=(perf_counter_ns() - created_at) / 1e9,
                             prediction_duration=msg.prediction_duration,
                             probabilities=np.array(msg.probabilities, dtype=np.float32),
                             is_interruption=False,
                             detection_delay=time.time() - overlap_started_at,
                         )
-                        if entry is None:
-                            continue
                         logger.trace(
                             "interruption inference done",
                             extra={

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -795,6 +795,10 @@ class InterruptionHttpStream(InterruptionStreamBase):
             self._opts.min_frames = math.ceil(min_interruption_duration * _FRAMES_PER_SECOND)
 
     async def _run(self) -> None:
+        # HTTP has no connection handshake. Once retry backoff finishes, the
+        # stream is ready to accept a new speech boundary and prediction.
+        self._model._set_state("active")
+
         async def _send_task(input_ch: aio.Chan[npt.NDArray[np.int16]]) -> None:
             async for data in input_ch:
                 if (

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -451,6 +451,8 @@ class AdaptiveInterruptionDetector(
     def stream(
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> InterruptionHttpStream | InterruptionWebSocketStream:
+        if self._state == "closed":
+            self._set_state("connecting" if self._opts.use_proxy else "active")
         try:
             stream: InterruptionHttpStream | InterruptionWebSocketStream
             if self._opts.use_proxy:
@@ -462,6 +464,11 @@ class AdaptiveInterruptionDetector(
             raise
         self._streams.add(stream)
         return stream
+
+    def _stream_closed(self, stream: InterruptionHttpStream | InterruptionWebSocketStream) -> None:
+        self._streams.discard(stream)
+        if not self._streams and self._state != "fallback":
+            self._set_state("closed")
 
     def update_options(
         self,
@@ -597,7 +604,7 @@ class InterruptionStreamBase(ABC):
             await self._metrics_task
         finally:
             await self._tee_aiter.aclose()
-            self._model._set_state("closed")
+            self._model._stream_closed(self)
 
     async def __anext__(self) -> OverlappingSpeechEvent:
         try:

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -510,7 +510,11 @@ class InterruptionStreamBase(ABC):
             dtype=np.int16,
             sample_rate=self._opts.sample_rate,
         )
-        self._cache = BoundedDict[int, InterruptionCacheEntry](maxsize=10)
+        request_cache_size = max(
+            10,
+            math.ceil(self._opts.inference_timeout / self._opts.detection_interval) + 2,
+        )
+        self._cache = BoundedDict[int, InterruptionCacheEntry](maxsize=request_cache_size)
         self._tee_aiter = aio.itertools.tee(self._event_ch, 2)
         self._event_aiter, monitor_aiter = self._tee_aiter
         self._metrics_task = asyncio.create_task(

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -70,6 +70,22 @@ class InterruptionDetectionError(BaseModel):
     recoverable: bool
 
 
+InterruptionDetectorState: TypeAlias = Literal[
+    "connecting", "active", "reconnecting", "fallback", "closed"
+]
+
+
+class InterruptionDetectionStateChangedEvent(BaseModel):
+    """A lifecycle transition emitted by an adaptive interruption detector."""
+
+    type: Literal["state_changed"] = "state_changed"
+    timestamp: float = Field(default_factory=time.time)
+    previous_state: InterruptionDetectorState
+    state: InterruptionDetectorState
+    reason: str | None = None
+    retry_count: int = 0
+
+
 @dataclass(slots=True, kw_only=True)
 class InterruptionOptions:
     sample_rate: int
@@ -263,6 +279,7 @@ class AdaptiveInterruptionDetector(
             "overlapping_speech",
             "error",
             "metrics_collected",
+            "state_changed",
         ]
     ],
 ):
@@ -279,6 +296,7 @@ class AdaptiveInterruptionDetector(
         api_key: str | None = None,
         api_secret: str | None = None,
         http_session: aiohttp.ClientSession | None = None,
+        transport: Literal["auto", "http", "websocket"] = "auto",
     ) -> None:
         """
         Initialize a AdaptiveInterruptionDetector instance.
@@ -294,6 +312,8 @@ class AdaptiveInterruptionDetector(
             api_key (str, optional): The API key for the interruption detection, defaults to the LIVEKIT_INFERENCE_API_KEY environment variable.
             api_secret (str, optional): The API secret for the interruption detection, defaults to the LIVEKIT_INFERENCE_API_SECRET environment variable.
             http_session (aiohttp.ClientSession, optional): The HTTP session to use for the interruption detection.
+            transport: Transport used by the detector. ``auto`` preserves the existing
+                hosted-WebSocket/custom-HTTP behavior.
         """
         super().__init__()
         if max_audio_duration > 3.0:
@@ -329,9 +349,9 @@ class AdaptiveInterruptionDetector(
                     "api_secret is required, either as argument or set LIVEKIT_API_SECRET environmental variable"
                 )
 
-            use_proxy = True
-        else:
-            use_proxy = False
+        if transport not in ("auto", "http", "websocket"):
+            raise ValueError("transport must be one of: auto, http, websocket")
+        use_proxy = is_inference_url if transport == "auto" else transport == "websocket"
 
         self._opts = InterruptionOptions(
             sample_rate=SAMPLE_RATE,
@@ -350,6 +370,7 @@ class AdaptiveInterruptionDetector(
         self._sample_rate = SAMPLE_RATE
         self._session = http_session
         self._streams = weakref.WeakSet[InterruptionHttpStream | InterruptionWebSocketStream]()
+        self._state: InterruptionDetectorState = "connecting" if use_proxy else "active"
 
         logger.info(
             "adaptive interruption detector initialized",
@@ -381,6 +402,37 @@ class AdaptiveInterruptionDetector(
     def sample_rate(self) -> int:
         return self._sample_rate
 
+    @property
+    def state(self) -> InterruptionDetectorState:
+        return self._state
+
+    def _set_state(
+        self,
+        state: InterruptionDetectorState,
+        *,
+        reason: str | None = None,
+        retry_count: int = 0,
+    ) -> None:
+        previous_state = self._state
+        if previous_state == state and state != "reconnecting":
+            return
+        self._state = state
+        self.emit(
+            "state_changed",
+            InterruptionDetectionStateChangedEvent(
+                previous_state=previous_state,
+                state=state,
+                reason=reason,
+                retry_count=retry_count,
+            ),
+        )
+
+    def fail(self, error: Exception) -> None:
+        """Permanently fail this detector and let its owner fall back safely."""
+
+        self._set_state("fallback", reason=str(error))
+        self._emit_error(error, recoverable=False)
+
     def _emit_error(self, api_error: Exception, recoverable: bool) -> None:
         self.emit(
             "error",
@@ -406,7 +458,7 @@ class AdaptiveInterruptionDetector(
             else:
                 stream = InterruptionHttpStream(model=self, conn_options=conn_options)
         except Exception as e:
-            self._emit_error(e, recoverable=False)
+            self.fail(e)
             raise
         self._streams.add(stream)
         return stream
@@ -477,14 +529,19 @@ class InterruptionStreamBase(ABC):
                 return await self._run()
             except APIError as e:
                 if max_retries == 0 or not e.retryable:
+                    self._model._set_state("fallback", reason=str(e), retry_count=self._num_retries)
                     self._emit_error(e, recoverable=False)
                     raise
                 elif self._num_retries == max_retries:
+                    self._model._set_state("fallback", reason=str(e), retry_count=self._num_retries)
                     self._emit_error(e, recoverable=False)
                     raise APIConnectionError(
                         f"failed to detect interruption after {self._num_retries} attempts",
                     ) from e
                 else:
+                    self._model._set_state(
+                        "reconnecting", reason=str(e), retry_count=self._num_retries + 1
+                    )
                     self._emit_error(e, recoverable=True)
 
                     retry_interval = self._conn_options._interval_for_retry(self._num_retries)
@@ -498,9 +555,16 @@ class InterruptionStreamBase(ABC):
                     )
                     await asyncio.sleep(retry_interval)
 
+                    self._cache.clear()
+                    self._overlap_started = False
+                    self._overlap_started_at = None
+                    self._user_speech_span = None
+                    await self._num_requests.set(0)
+
                 self._num_retries += 1
 
             except Exception as e:
+                self._model._set_state("fallback", reason=str(e), retry_count=self._num_retries)
                 self._emit_error(e, recoverable=False)
                 raise
 
@@ -533,6 +597,7 @@ class InterruptionStreamBase(ABC):
             await self._metrics_task
         finally:
             await self._tee_aiter.aclose()
+            self._model._set_state("closed")
 
     async def __anext__(self) -> OverlappingSpeechEvent:
         try:
@@ -608,19 +673,17 @@ class InterruptionStreamBase(ABC):
                     self._overlap_started = True
                     self._accumulated_samples = 0
                     self._overlap_count += 1
-                    # include the audio prefix in the window and
-                    # only shift (remove leading silence) when the first overlap speech started
-                    # otherwise, keep the existing data
-                    if self._overlap_count == 1:
-                        shift_size = max(
-                            0,
-                            len(self._audio_buffer)
-                            - (
-                                int(input_frame._speech_duration * self._sample_rate)
-                                + self._prefix_size
-                            ),
-                        )
-                        self._audio_buffer.shift(shift_size)
+                    # Re-anchor every overlap. Otherwise a later overlap can include stale
+                    # audio from an earlier attempt and produce a false interruption.
+                    shift_size = max(
+                        0,
+                        len(self._audio_buffer)
+                        - (
+                            int(input_frame._speech_duration * self._sample_rate)
+                            + self._prefix_size
+                        ),
+                    )
+                    self._audio_buffer.shift(shift_size)
                     logger.trace(
                         "overlap speech started, starting interruption inference",
                         extra={
@@ -782,6 +845,7 @@ class InterruptionHttpStream(InterruptionStreamBase):
                             ),
                         }
                     )
+                    self._model._set_state("active")
 
                     logger.trace(
                         "interruption inference done",
@@ -924,6 +988,7 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
             self._opts.threshold = threshold
         if is_given(min_interruption_duration):
             self._opts.min_frames = math.ceil(min_interruption_duration * _FRAMES_PER_SECOND)
+        self._model._set_state("reconnecting", reason="interruption options updated")
         self._reconnect_event.set()
 
     async def _run(self) -> None:
@@ -933,22 +998,8 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
             ws: aiohttp.ClientWebSocketResponse, input_ch: aio.Chan[npt.NDArray[np.int16]]
         ) -> None:
             nonlocal closing_ws
-            timeout_ns = int(self._opts.inference_timeout * 1e9)
 
             async for audio_data in input_ch:
-                now = perf_counter_ns()
-                for _key, entry in self._cache.items():
-                    if entry.total_duration is not None:
-                        continue
-                    if now - entry.created_at > timeout_ns:
-                        raise APIStatusError(
-                            f"interruption inference timed out after "
-                            f"{(now - entry.created_at) / 1e9:.1f}s (ws)",
-                            status_code=408,
-                            retryable=False,
-                        )
-                    break  # oldest unanswered entry is still within timeout
-
                 await self._num_requests.increment()
                 created_at = perf_counter_ns()
                 header = struct.pack("<Q", created_at)  # 8 bytes
@@ -963,6 +1014,24 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                 type=InterruptionWSMessageType.SESSION_CLOSE,
             )
             await ws.send_str(msg.model_dump_json())
+
+        async def timeout_task() -> None:
+            timeout_ns = int(self._opts.inference_timeout * 1e9)
+            interval = max(0.01, min(self._opts.inference_timeout / 2, 0.1))
+            while True:
+                await asyncio.sleep(interval)
+                now = perf_counter_ns()
+                for _key, entry in self._cache.items():
+                    if entry.total_duration is not None:
+                        continue
+                    if now - entry.created_at > timeout_ns:
+                        raise APIStatusError(
+                            f"interruption inference timed out after "
+                            f"{(now - entry.created_at) / 1e9:.1f}s (ws)",
+                            status_code=408,
+                            retryable=True,
+                        )
+                    break
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws
@@ -1076,6 +1145,7 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                     asyncio.create_task(self._forward_data(data_ch)),
                     asyncio.create_task(send_task(ws, data_ch)),
                     asyncio.create_task(recv_task(ws)),
+                    asyncio.create_task(timeout_task()),
                 ]
                 tasks_group = asyncio.gather(*tasks)
                 wait_reconnect_task = asyncio.create_task(self._reconnect_event.wait())
@@ -1141,12 +1211,12 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                 raise APIStatusError(
                     "LiveKit Adaptive Interruption quota exceeded",
                     status_code=e.status,
-                    retryable=False,
+                    retryable=True,
                 ) from e
             elif isinstance(e, asyncio.TimeoutError):
                 raise APIConnectionError(
                     "failed to connect to LiveKit Adaptive Interruption: timeout",
-                    retryable=False,
+                    retryable=True,
                 ) from e
             raise APIConnectionError("failed to connect to LiveKit Adaptive Interruption") from e
 
@@ -1156,8 +1226,33 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                 settings=settings,
             )
             await ws.send_str(msg.model_dump_json())
+            ws_msg = await asyncio.wait_for(ws.receive(), timeout=self._opts.inference_timeout)
+            if ws_msg.type != aiohttp.WSMsgType.TEXT:
+                raise APIConnectionError(
+                    f"unexpected session.create response: {ws_msg.type}", retryable=True
+                )
+            response = InterruptionWSMessage.validate_json(ws_msg.data)
+            if isinstance(response, InterruptionWSErrorMessage):
+                raise APIStatusError(
+                    f"LiveKit Adaptive Interruption returned error: {response.code}",
+                    body=response.message,
+                    status_code=response.code,
+                )
+            if not isinstance(response, InterruptionWSSessionCreatedMessage):
+                raise APIConnectionError(
+                    f"unexpected session.create response: {response.type}", retryable=False
+                )
+            self._model._set_state("active", retry_count=self._num_retries)
+        except asyncio.TimeoutError as e:
+            await ws.close()
+            raise APIConnectionError(
+                "timed out waiting for session.created from LiveKit Adaptive Interruption",
+                retryable=True,
+            ) from e
         except Exception as e:
             await ws.close()
+            if isinstance(e, APIError):
+                raise
             raise APIConnectionError(
                 "failed to send session.create message to LiveKit Adaptive Interruption"
             ) from e

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -732,7 +732,7 @@ class InterruptionStreamBase(ABC):
                     self._overlap_started = False
                     self._accumulated_samples = 0
                     self._overlap_started_at = None
-                    # we don't clear the cache here since responses might be in flight
+                    self._cache.clear()
                 case rtc.AudioFrame() if self._agent_speech_started:
                     samples_written = self._audio_buffer.push_frame(input_frame)
                     self._accumulated_samples += samples_written
@@ -1024,11 +1024,11 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                 await self._num_requests.increment()
                 created_at = perf_counter_ns()
                 header = struct.pack("<Q", created_at)  # 8 bytes
-                await ws.send_bytes(header + audio_data.tobytes())
                 self._cache[created_at] = InterruptionCacheEntry(
                     created_at=created_at,
                     speech_input=audio_data,
                 )
+                await ws.send_bytes(header + audio_data.tobytes())
 
             closing_ws = True
             msg = InterruptionWSSessionCloseMessage(
@@ -1090,61 +1090,63 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                         pass
                     case InterruptionWSDetectedMessage():
                         created_at = msg.created_at
-                        if (
-                            overlap_started_at := self._overlap_started_at
-                        ) is not None and self._overlap_started:
-                            entry = self._cache.set_or_update(
-                                created_at,
-                                lambda c=created_at: InterruptionCacheEntry(created_at=c),  # type: ignore[misc]
-                                total_duration=(perf_counter_ns() - created_at) / 1e9,
-                                probabilities=np.array(msg.probabilities, dtype=np.float32),
-                                is_interruption=True,
-                                prediction_duration=msg.prediction_duration,
-                                detection_delay=time.time() - overlap_started_at,
-                            )
-                            if self._user_speech_span:
-                                self._update_user_speech_span(self._user_speech_span, entry)
-                                self._user_speech_span = None
-                            logger.debug(
-                                "interruption detected",
-                                extra={
-                                    "total_duration": entry.get_total_duration(),
-                                    "prediction_duration": entry.get_prediction_duration(),
-                                    "detection_delay": entry.get_detection_delay(),
-                                    "probability": entry.get_probability(),
-                                },
-                            )
-                            ev = OverlappingSpeechEvent.from_cache_entry(
-                                entry=entry,
-                                is_interruption=True,
-                                started_at=overlap_started_at,
-                                ended_at=time.time(),
-                            )
-                            ev.num_requests = await self._num_requests.get_and_reset()
-                            self.send(ev)
-                            self._overlap_started = False
+                        overlap_started_at = self._overlap_started_at
+                        if overlap_started_at is None or not self._overlap_started:
+                            continue
+                        entry = self._cache.update_value(
+                            created_at,
+                            total_duration=(perf_counter_ns() - created_at) / 1e9,
+                            probabilities=np.array(msg.probabilities, dtype=np.float32),
+                            is_interruption=True,
+                            prediction_duration=msg.prediction_duration,
+                            detection_delay=time.time() - overlap_started_at,
+                        )
+                        if entry is None:
+                            continue
+                        if self._user_speech_span:
+                            self._update_user_speech_span(self._user_speech_span, entry)
+                            self._user_speech_span = None
+                        logger.debug(
+                            "interruption detected",
+                            extra={
+                                "total_duration": entry.get_total_duration(),
+                                "prediction_duration": entry.get_prediction_duration(),
+                                "detection_delay": entry.get_detection_delay(),
+                                "probability": entry.get_probability(),
+                            },
+                        )
+                        ev = OverlappingSpeechEvent.from_cache_entry(
+                            entry=entry,
+                            is_interruption=True,
+                            started_at=overlap_started_at,
+                            ended_at=time.time(),
+                        )
+                        ev.num_requests = await self._num_requests.get_and_reset()
+                        self.send(ev)
+                        self._overlap_started = False
                     case InterruptionWSInferenceDoneMessage():
                         created_at = msg.created_at
-                        if (
-                            overlap_started_at := self._overlap_started_at
-                        ) is not None and self._overlap_started:
-                            entry = self._cache.set_or_update(
-                                created_at,
-                                lambda c=created_at: InterruptionCacheEntry(created_at=c),  # type: ignore[misc]
-                                total_duration=(perf_counter_ns() - created_at) / 1e9,
-                                prediction_duration=msg.prediction_duration,
-                                probabilities=np.array(msg.probabilities, dtype=np.float32),
-                                is_interruption=False,
-                                detection_delay=time.time() - overlap_started_at,
-                            )
-                            logger.trace(
-                                "interruption inference done",
-                                extra={
-                                    "total_duration": entry.get_total_duration(),
-                                    "prediction_duration": entry.get_prediction_duration(),
-                                    "probability": entry.get_probability(),
-                                },
-                            )
+                        overlap_started_at = self._overlap_started_at
+                        if overlap_started_at is None or not self._overlap_started:
+                            continue
+                        entry = self._cache.update_value(
+                            created_at,
+                            total_duration=(perf_counter_ns() - created_at) / 1e9,
+                            prediction_duration=msg.prediction_duration,
+                            probabilities=np.array(msg.probabilities, dtype=np.float32),
+                            is_interruption=False,
+                            detection_delay=time.time() - overlap_started_at,
+                        )
+                        if entry is None:
+                            continue
+                        logger.trace(
+                            "interruption inference done",
+                            extra={
+                                "total_duration": entry.get_total_duration(),
+                                "prediction_duration": entry.get_prediction_duration(),
+                                "probability": entry.get_probability(),
+                            },
+                        )
                     case InterruptionWSErrorMessage():
                         raise APIStatusError(
                             f"LiveKit Adaptive Interruption returned error: {msg.code}",

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -12,7 +12,7 @@ from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass, field
 from enum import Enum
 from time import perf_counter_ns
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias, cast
 
 import aiohttp
 import numpy as np
@@ -604,7 +604,9 @@ class InterruptionStreamBase(ABC):
             await self._metrics_task
         finally:
             await self._tee_aiter.aclose()
-            self._model._stream_closed(self)
+            self._model._stream_closed(
+                cast(InterruptionHttpStream | InterruptionWebSocketStream, self)
+            )
 
     async def __anext__(self) -> OverlappingSpeechEvent:
         try:

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -414,6 +414,12 @@ class AdaptiveInterruptionDetector(
         retry_count: int = 0,
     ) -> None:
         previous_state = self._state
+        if previous_state == "fallback" and state != "fallback":
+            logger.debug(
+                "ignoring interruption detector state transition from terminal fallback",
+                extra={"requested_state": state, "reason": reason},
+            )
+            return
         if previous_state == state and state != "reconnecting":
             return
         self._state = state
@@ -451,6 +457,8 @@ class AdaptiveInterruptionDetector(
     def stream(
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> InterruptionHttpStream | InterruptionWebSocketStream:
+        if self._state == "fallback":
+            raise RuntimeError("adaptive interruption detector has terminally failed")
         if self._state == "closed":
             self._set_state("connecting" if self._opts.use_proxy else "active")
         try:

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -46,6 +46,9 @@ class Agent:
         stt: NotGivenOr[stt.STT | STTModels | str | None] = NOT_GIVEN,
         vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
         turn_handling: NotGivenOr[TurnHandlingOptions] = NOT_GIVEN,
+        interruption_detection: NotGivenOr[
+            Literal["adaptive", "vad"] | inference.AdaptiveInterruptionDetector
+        ] = NOT_GIVEN,
         tool_handling: NotGivenOr[ToolHandlingOptions] = NOT_GIVEN,
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | LLMModels | str | None] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | TTSModels | str | None] = NOT_GIVEN,
@@ -95,11 +98,13 @@ class Agent:
         self._vad = vad
 
         self._allow_interruptions: NotGivenOr[bool] = NOT_GIVEN
-        self._interruption_detection: NotGivenOr[Literal["adaptive", "vad"]] = NOT_GIVEN
+        self._interruption_detection: NotGivenOr[
+            Literal["adaptive", "vad"] | inference.AdaptiveInterruptionDetector
+        ] = interruption_detection
         if is_given(raw_interruption := turn_handling.get("interruption", NOT_GIVEN)):
             if "enabled" in raw_interruption:
                 self._allow_interruptions = raw_interruption["enabled"]
-            if "mode" in raw_interruption:
+            if "mode" in raw_interruption and not is_given(interruption_detection):
                 self._interruption_detection = raw_interruption["mode"]
         endpointing = turn_handling.get("endpointing", {})
         self._min_consecutive_speech_delay = min_consecutive_speech_delay
@@ -166,7 +171,9 @@ class Agent:
         return _ReadOnlyChatContext(self._chat_ctx.items)
 
     @property
-    def interruption_detection(self) -> NotGivenOr[Literal["adaptive", "vad"]]:
+    def interruption_detection(
+        self,
+    ) -> NotGivenOr[Literal["adaptive", "vad"] | inference.AdaptiveInterruptionDetector]:
         return self._interruption_detection
 
     async def update_instructions(self, instructions: str) -> None:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -415,7 +415,10 @@ class AgentActivity(RecognitionHooks):
 
     @property
     def interruption_enabled(self) -> bool:
-        return self._interruption_detection_enabled
+        return self._interruption_detection_enabled and (
+            self._audio_recognition is None
+            or self._audio_recognition.adaptive_interruption_active
+        )
 
     @property
     def mcp_servers(self) -> list[mcp.MCPServer] | None:
@@ -843,6 +846,7 @@ class AgentActivity(RecognitionHooks):
             self._interruption_detector.on("metrics_collected", self._on_metrics_collected)
             self._interruption_detector.on("error", self._on_error)
             self._interruption_detector.on("overlapping_speech", self._on_overlap_speech_ended)
+            self._interruption_detector.on("state_changed", self._on_interruption_state_changed)
 
         if isinstance(self.llm, llm.RealtimeModel):
             rt_reused = reuse_resources is not None and reuse_resources.rt_session is not None
@@ -1120,6 +1124,7 @@ class AgentActivity(RecognitionHooks):
             self._interruption_detector.off("metrics_collected", self._on_metrics_collected)
             self._interruption_detector.off("error", self._on_error)
             self._interruption_detector.off("overlapping_speech", self._on_overlap_speech_ended)
+            self._interruption_detector.off("state_changed", self._on_interruption_state_changed)
 
         if self._rt_session is not None:
             await self._rt_session.aclose()
@@ -1847,6 +1852,35 @@ class AgentActivity(RecognitionHooks):
 
         self._session._on_error(error)
 
+    def _on_interruption_state_changed(
+        self, event: inference.InterruptionDetectionStateChangedEvent
+    ) -> None:
+        if event.state == "active":
+            if self._audio_recognition:
+                self._audio_recognition.set_interruption_detection_available(True)
+            logger.info(
+                "adaptive interruption detector active",
+                extra={"previous_state": event.previous_state, "retry_count": event.retry_count},
+            )
+            return
+
+        if event.state in ("connecting", "reconnecting"):
+            self._restore_interruption_by_audio_activity()
+            if self._audio_recognition:
+                self._audio_recognition.set_interruption_detection_available(False)
+            logger.info(
+                "adaptive interruption detector unavailable; VAD owns interruption",
+                extra={
+                    "state": event.state,
+                    "reason": event.reason,
+                    "retry_count": event.retry_count,
+                },
+            )
+            return
+
+        if event.state == "fallback":
+            self._fallback_to_vad_interruption()
+
     def _on_overlap_speech_ended(self, ev: inference.OverlappingSpeechEvent) -> None:
         if ev.is_interruption:
             self._interruption_detected = True
@@ -2010,12 +2044,13 @@ class AgentActivity(RecognitionHooks):
                 else None
             )
 
-            if dyn_min_words > 0 and word_count < dyn_min_words:
+            detector_overlap = source == "overlap"
+            if not detector_overlap and dyn_min_words > 0 and word_count < dyn_min_words:
                 return
 
             if opts.interruption_ignore_words:
                 is_empty = text.strip() == ""
-                if is_empty and dyn_min_words > 0:
+                if not detector_overlap and is_empty and dyn_min_words > 0:
                     return
                 ignore_match = (
                     _matches_ignore_words(text, opts.interruption_ignore_words)
@@ -2143,7 +2178,7 @@ class AgentActivity(RecognitionHooks):
                 ended_at=speech_end_time,
                 user_speaking_span=self._session._user_speaking_span,
                 interruption=self._interruption_detected
-                if self._interruption_detection_enabled
+                if self.interruption_enabled
                 else NOT_GIVEN,
             )
 
@@ -4235,6 +4270,9 @@ class AgentActivity(RecognitionHooks):
 
     def _disable_vad_interruption_soon(self) -> None:
         """Disable VAD interruption after the backchannel boundary expires."""
+        if not self.interruption_enabled:
+            self._restore_interruption_by_audio_activity()
+            return
         if self._audio_recognition and self._audio_recognition.backchannel_boundary_active:
 
             def _disable_vad_interruption() -> None:
@@ -4277,6 +4315,7 @@ class AgentActivity(RecognitionHooks):
             self._interruption_detector.off("metrics_collected", self._on_metrics_collected)
             self._interruption_detector.off("error", self._on_error)
             self._interruption_detector.off("overlapping_speech", self._on_overlap_speech_ended)
+            self._interruption_detector.off("state_changed", self._on_interruption_state_changed)
 
         if self._audio_recognition:
             # this also releases any held transcripts
@@ -4318,6 +4357,14 @@ class AgentActivity(RecognitionHooks):
         return self._agent.vad if is_given(self._agent.vad) else self._session.vad
 
     def _resolve_interruption_detection(self) -> inference.AdaptiveInterruptionDetector | None:
+        configured_detector = (
+            self._agent.interruption_detection
+            if is_given(self._agent.interruption_detection)
+            and isinstance(
+                self._agent.interruption_detection, inference.AdaptiveInterruptionDetector
+            )
+            else None
+        )
         if not (
             self.stt is not None
             and self.stt.capabilities.aligned_transcript
@@ -4327,8 +4374,11 @@ class AgentActivity(RecognitionHooks):
             and not isinstance(self.llm, llm.RealtimeModel)
         ):
             if (
-                is_given(self._agent.interruption_detection)
-                and self._agent.interruption_detection == "adaptive"
+                configured_detector is not None
+                or (
+                    is_given(self._agent.interruption_detection)
+                    and self._agent.interruption_detection == "adaptive"
+                )
             ) or (
                 is_given(self._session.interruption_detection)
                 and self._session.interruption_detection == "adaptive"
@@ -4340,6 +4390,9 @@ class AgentActivity(RecognitionHooks):
 
         if not self.allow_interruptions:
             return None
+
+        if configured_detector is not None:
+            return configured_detector
 
         if (
             is_given(self._agent.interruption_detection)

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1856,7 +1856,7 @@ class AgentActivity(RecognitionHooks):
     ) -> None:
         if event.state == "active":
             if self._audio_recognition:
-                self._audio_recognition.set_interruption_detection_available(True)
+                self._audio_recognition._sync_interruption_detection()
             logger.info(
                 "adaptive interruption detector active",
                 extra={"previous_state": event.previous_state, "retry_count": event.retry_count},
@@ -1866,7 +1866,7 @@ class AgentActivity(RecognitionHooks):
         if event.state in ("connecting", "reconnecting"):
             self._restore_interruption_by_audio_activity()
             if self._audio_recognition:
-                self._audio_recognition.set_interruption_detection_available(False)
+                self._audio_recognition._sync_interruption_detection()
             logger.info(
                 "adaptive interruption detector unavailable; VAD owns interruption",
                 extra={

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -416,8 +416,7 @@ class AgentActivity(RecognitionHooks):
     @property
     def interruption_enabled(self) -> bool:
         return self._interruption_detection_enabled and (
-            self._audio_recognition is None
-            or self._audio_recognition.adaptive_interruption_active
+            self._audio_recognition is None or self._audio_recognition.adaptive_interruption_active
         )
 
     @property

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -42,6 +42,35 @@ if TYPE_CHECKING:
 MIN_LANGUAGE_DETECTION_LENGTH = 5
 # Mirrors turn_detector.base.MAX_HISTORY_TURNS for tracing
 _EOU_MAX_HISTORY_TURNS = 6
+_INTERRUPTION_STREAM_CLOSE_TIMEOUT = 1.0
+
+
+def _consume_interruption_stream_close(task: asyncio.Task[None]) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.exception("adaptive interruption stream close failed")
+
+
+async def _close_interruption_stream(stream: Any) -> None:
+    close_task = asyncio.create_task(stream.aclose())
+    try:
+        done, _ = await asyncio.wait({close_task}, timeout=_INTERRUPTION_STREAM_CLOSE_TIMEOUT)
+    except asyncio.CancelledError:
+        close_task.cancel()
+        close_task.add_done_callback(_consume_interruption_stream_close)
+        raise
+    if not done:
+        close_task.cancel()
+        close_task.add_done_callback(_consume_interruption_stream_close)
+        logger.warning(
+            "adaptive interruption stream close timed out",
+            extra={"timeout_seconds": _INTERRUPTION_STREAM_CLOSE_TIMEOUT},
+        )
+        return
+    _consume_interruption_stream_close(close_task)
 
 
 @dataclass
@@ -201,10 +230,7 @@ class AudioRecognition:
         self._input_started_at: float | None = None
         self._ignore_user_transcript_until: NotGivenOr[float] = NOT_GIVEN
         self._transcript_buffer: deque[SpeechEvent] = deque()
-        self._interruption_ready: bool = (
-            interruption_detection is not None and interruption_detection.state == "active"
-        )
-        self._interruption_enabled: bool = self._interruption_ready and vad is not None
+        self._interruption_enabled: bool = self._adaptive_interruption_ready and vad is not None
         self._agent_speaking: bool = False
 
         _backchannel_boundary: float | tuple[float, float] | None = (
@@ -307,6 +333,13 @@ class AudioRecognition:
             and not self._interruption_ch.closed
         )
 
+    @property
+    def _adaptive_interruption_ready(self) -> bool:
+        return (
+            self._interruption_detection is not None
+            and self._interruption_detection.state == "active"
+        )
+
     # region: boundary for adaptive interruption detection
 
     @property
@@ -331,7 +364,7 @@ class AudioRecognition:
     # endregion
 
     def on_start_of_agent_speech(self, started_at: float) -> None:
-        if self._interruption_ready and not self._agent_speaking:
+        if self._adaptive_interruption_ready and not self._agent_speaking:
             self._interruption_enabled = self._vad is not None
         self._agent_speaking = True
         self._endpointing.on_start_of_agent_speech(started_at=started_at)
@@ -356,7 +389,7 @@ class AudioRecognition:
 
         if not self.adaptive_interruption_active:
             self._agent_speaking = False
-            if self._interruption_ready:
+            if self._adaptive_interruption_ready:
                 # A reconnect can complete while the agent is speaking. Start using
                 # the detector only after that speech finishes, at a clean boundary.
                 self._interruption_enabled = self._vad is not None
@@ -730,7 +763,7 @@ class AudioRecognition:
             self._vad_ch = None
             self._vad_stream = None
 
-        self._interruption_enabled = self._interruption_ready and self._vad is not None
+        self._interruption_enabled = self._adaptive_interruption_ready and self._vad is not None
 
     async def detach_stt(self) -> _STTPipeline | None:
         """Detach the STT pipeline for handoff to another AudioRecognition.
@@ -753,9 +786,6 @@ class AudioRecognition:
         self, interruption_detection: inference.AdaptiveInterruptionDetector | None
     ) -> None:
         self._interruption_detection = interruption_detection
-        self._interruption_ready = (
-            interruption_detection is not None and interruption_detection.state == "active"
-        )
         if interruption_detection is not None:
             self._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
             self._interruption_atask = asyncio.create_task(
@@ -777,22 +807,18 @@ class AudioRecognition:
             flush_task.add_done_callback(lambda _: self._tasks.discard(flush_task))
             self._tasks.add(flush_task)
 
-        self._interruption_enabled = self._interruption_ready and self._vad is not None
+        self._interruption_enabled = self._adaptive_interruption_ready and self._vad is not None
 
-    def set_interruption_detection_available(self, available: bool) -> None:
+    def _sync_interruption_detection(self) -> None:
         """Switch interruption ownership without tearing down the detector stream."""
 
-        ready = (
-            available
-            and self._interruption_detection is not None
-            and self._interruption_detection.state == "active"
-        )
         was_enabled = self._interruption_enabled
-        self._interruption_ready = ready
         # Do not activate a freshly reconnected detector in the middle of agent
         # speech: it did not receive that speech's start sentinel.
         self._interruption_enabled = (
-            ready and self._vad is not None and not (self._agent_speaking and not was_enabled)
+            self._adaptive_interruption_ready
+            and self._vad is not None
+            and not (self._agent_speaking and not was_enabled)
         )
 
         if was_enabled and not self._interruption_enabled:
@@ -1494,7 +1520,7 @@ class AudioRecognition:
             return
         finally:
             await aio.cancel_and_wait(forward_task)
-            await stream.aclose()
+            await _close_interruption_stream(stream)
 
     def _ensure_user_turn_span(self, start_time: float | None = None) -> trace.Span:
         if self._user_turn_span and self._user_turn_span.is_recording():

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -201,7 +201,10 @@ class AudioRecognition:
         self._input_started_at: float | None = None
         self._ignore_user_transcript_until: NotGivenOr[float] = NOT_GIVEN
         self._transcript_buffer: deque[SpeechEvent] = deque()
-        self._interruption_enabled: bool = interruption_detection is not None and vad is not None
+        self._interruption_ready: bool = (
+            interruption_detection is not None and interruption_detection.state == "active"
+        )
+        self._interruption_enabled: bool = self._interruption_ready and vad is not None
         self._agent_speaking: bool = False
 
         _backchannel_boundary: float | tuple[float, float] | None = (
@@ -328,6 +331,8 @@ class AudioRecognition:
     # endregion
 
     def on_start_of_agent_speech(self, started_at: float) -> None:
+        if self._interruption_ready and not self._agent_speaking:
+            self._interruption_enabled = self._vad is not None
         self._agent_speaking = True
         self._endpointing.on_start_of_agent_speech(started_at=started_at)
 
@@ -351,6 +356,10 @@ class AudioRecognition:
 
         if not self.adaptive_interruption_active:
             self._agent_speaking = False
+            if self._interruption_ready:
+                # A reconnect can complete while the agent is speaking. Start using
+                # the detector only after that speech finishes, at a clean boundary.
+                self._interruption_enabled = self._vad is not None
             return
 
         self._interruption_ch.send_nowait(_AgentSpeechEndedSentinel())  # type: ignore[union-attr]
@@ -721,9 +730,7 @@ class AudioRecognition:
             self._vad_ch = None
             self._vad_stream = None
 
-        self._interruption_enabled = (
-            self._interruption_detection is not None and self._vad is not None
-        )
+        self._interruption_enabled = self._interruption_ready and self._vad is not None
 
     async def detach_stt(self) -> _STTPipeline | None:
         """Detach the STT pipeline for handoff to another AudioRecognition.
@@ -746,6 +753,9 @@ class AudioRecognition:
         self, interruption_detection: inference.AdaptiveInterruptionDetector | None
     ) -> None:
         self._interruption_detection = interruption_detection
+        self._interruption_ready = (
+            interruption_detection is not None and interruption_detection.state == "active"
+        )
         if interruption_detection is not None:
             self._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
             self._interruption_atask = asyncio.create_task(
@@ -767,9 +777,31 @@ class AudioRecognition:
             flush_task.add_done_callback(lambda _: self._tasks.discard(flush_task))
             self._tasks.add(flush_task)
 
-        self._interruption_enabled = (
-            self._interruption_detection is not None and self._vad is not None
+        self._interruption_enabled = self._interruption_ready and self._vad is not None
+
+    def set_interruption_detection_available(self, available: bool) -> None:
+        """Switch interruption ownership without tearing down the detector stream."""
+
+        ready = (
+            available
+            and self._interruption_detection is not None
+            and self._interruption_detection.state == "active"
         )
+        was_enabled = self._interruption_enabled
+        self._interruption_ready = ready
+        # Do not activate a freshly reconnected detector in the middle of agent
+        # speech: it did not receive that speech's start sentinel.
+        self._interruption_enabled = ready and self._vad is not None and not (
+            self._agent_speaking and not was_enabled
+        )
+
+        if was_enabled and not self._interruption_enabled:
+            self._cancel_backchannel_boundary()
+            flush_task = asyncio.create_task(
+                self._flush_held_transcripts(cooldown=0.0, force=True)
+            )
+            flush_task.add_done_callback(lambda _: self._tasks.discard(flush_task))
+            self._tasks.add(flush_task)
 
     def clear_user_turn(self) -> None:
         self._audio_transcript = ""

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -791,15 +791,13 @@ class AudioRecognition:
         self._interruption_ready = ready
         # Do not activate a freshly reconnected detector in the middle of agent
         # speech: it did not receive that speech's start sentinel.
-        self._interruption_enabled = ready and self._vad is not None and not (
-            self._agent_speaking and not was_enabled
+        self._interruption_enabled = (
+            ready and self._vad is not None and not (self._agent_speaking and not was_enabled)
         )
 
         if was_enabled and not self._interruption_enabled:
             self._cancel_backchannel_boundary()
-            flush_task = asyncio.create_task(
-                self._flush_held_transcripts(cooldown=0.0, force=True)
-            )
+            flush_task = asyncio.create_task(self._flush_held_transcripts(cooldown=0.0, force=True))
             flush_task.add_done_callback(lambda _: self._tasks.discard(flush_task))
             self._tasks.add(flush_task)
 

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -291,9 +291,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
                 await self._playback_enabled.wait()
                 if self._fade_out_ms > 0:
                     # ramp the first frames back in so resume doesn't pop
-                    self._fade_in_remaining = int(
-                        self._fade_in_ms / 1000 * self._sample_rate_hz
-                    )
+                    self._fade_in_remaining = int(self._fade_in_ms / 1000 * self._sample_rate_hz)
                 # TODO(long): save the frames in the queue and play them later
                 # TODO(long): ignore frames from previous syllable
 

--- a/livekit-agents/tests/test_backchannel_latency.py
+++ b/livekit-agents/tests/test_backchannel_latency.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import time
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -180,6 +181,45 @@ def test_vad_start_keeps_context_when_speech_was_already_interrupted() -> None:
     assert activity._user_speech_started_during_interruptible_agent_speech is True
     assert activity._stt_eos_received is False
     assert updates[-1][0] == "speaking"
+
+
+def _activity_for_interruption_candidate(transcript: str) -> tuple[AgentActivity, Mock]:
+    opts = _opts(min_interruption_words=3)
+    opts.interruption["false_interruption_timeout"] = None
+    speech = Mock(interrupted=False, allow_interruptions=True)
+    activity = AgentActivity.__new__(AgentActivity)
+    activity._opts = opts
+    activity._agent = SimpleNamespace(stt=object(), llm=None)
+    activity._session = SimpleNamespace(
+        options=opts,
+        _aec_warmup_remaining=0,
+        _aec_warmup_timer=None,
+        agent_state="speaking",
+    )
+    activity._audio_recognition = SimpleNamespace(
+        current_transcript=transcript,
+        _endpointing=SimpleNamespace(overlapping=True),
+    )
+    activity._interruption_by_audio_activity_enabled = True
+    activity._rt_session = None
+    activity._current_speech = speech
+    activity._false_interruption_timer = None
+    activity._pause_enabled = lambda: False
+    activity._record_dynamic_continuation_collision = lambda: None
+    return activity, speech
+
+
+def test_detector_overlap_bypasses_min_words_but_not_ignore_words() -> None:
+    activity, speech = _activity_for_interruption_candidate("")
+    activity._interrupt_by_audio_activity(source="vad")
+    speech.interrupt.assert_not_called()
+
+    activity._interrupt_by_audio_activity(source="overlap")
+    speech.interrupt.assert_called_once_with()
+
+    ignored_activity, ignored_speech = _activity_for_interruption_candidate("네")
+    ignored_activity._interrupt_by_audio_activity(source="overlap")
+    ignored_speech.interrupt.assert_not_called()
 
 
 def test_suppressed_transcript_commits_without_latency_anchor() -> None:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -29,6 +29,7 @@ from livekit.agents.llm import (
 from livekit.agents.llm.chat_context import ChatContext, ChatMessage
 from livekit.agents.stt import SpeechData, SpeechEvent, SpeechEventType
 from livekit.agents.utils import aio
+from livekit.agents.voice import audio_recognition as audio_recognition_module
 from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnInfo
 from livekit.agents.voice.endpointing import BaseEndpointing
@@ -912,7 +913,7 @@ async def test_reconnected_detector_waits_for_agent_speech_boundary() -> None:
 
     try:
         detector._set_state("active")
-        recognition.set_interruption_detection_available(True)
+        recognition._sync_interruption_detection()
         assert recognition.adaptive_interruption_active is False
 
         recognition.on_end_of_agent_speech(ignore_user_transcript_until=time.time())
@@ -939,7 +940,7 @@ async def test_detector_state_switches_interruption_owner() -> None:
                 retry_count=1,
             )
         )
-        audio_recognition.set_interruption_detection_available.assert_called_once_with(False)
+        audio_recognition._sync_interruption_detection.assert_called_once_with()
         assert activity._interruption_by_audio_activity_enabled is True
 
         audio_recognition.reset_mock()
@@ -950,7 +951,7 @@ async def test_detector_state_switches_interruption_owner() -> None:
                 retry_count=1,
             )
         )
-        audio_recognition.set_interruption_detection_available.assert_called_once_with(True)
+        audio_recognition._sync_interruption_detection.assert_called_once_with()
 
         fallback = Mock()
         activity._fallback_to_vad_interruption = fallback
@@ -965,6 +966,44 @@ async def test_detector_state_switches_interruption_owner() -> None:
         fallback.assert_called_once_with()
     finally:
         await _close_test_session(session)
+
+
+async def test_interruption_stream_close_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        audio_recognition_module,
+        "_INTERRUPTION_STREAM_CLOSE_TIMEOUT",
+        0.01,
+    )
+
+    class _CancellationResistantStream:
+        def __init__(self) -> None:
+            self.close_task: asyncio.Task[None] | None = None
+            self.cancelled = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def aclose(self) -> None:
+            self.close_task = asyncio.current_task()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                await self.release.wait()
+
+    stream = _CancellationResistantStream()
+    await asyncio.wait_for(
+        audio_recognition_module._close_interruption_stream(stream),
+        timeout=0.1,
+    )
+
+    try:
+        await asyncio.wait_for(stream.cancelled.wait(), timeout=0.1)
+        assert stream.close_task is not None and not stream.close_task.done()
+    finally:
+        stream.release.set()
+        if stream.close_task is not None:
+            await asyncio.wait_for(stream.close_task, timeout=0.1)
 
 
 async def test_vad_fallback_uses_next_vad_inference_event(

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -890,6 +890,83 @@ async def test_interruption_detection_error_is_not_session_error() -> None:
         await _close_test_session(session)
 
 
+async def test_reconnected_detector_waits_for_agent_speech_boundary() -> None:
+    session = create_session(FakeActions())
+    detector = inference.AdaptiveInterruptionDetector(
+        base_url="http://localhost:9999",
+        api_key="test-key",
+        api_secret="test-secret",
+        transport="websocket",
+    )
+    recognition = AudioRecognition(
+        session,
+        hooks=_TestRecognitionHooks(),
+        endpointing=BaseEndpointing(min_delay=0.1, max_delay=1.0),
+        stt=None,
+        vad=MagicMock(),
+        interruption_detection=detector,
+        turn_detection="vad",
+    )
+    recognition._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
+    recognition._agent_speaking = True
+
+    try:
+        detector._set_state("active")
+        recognition.set_interruption_detection_available(True)
+        assert recognition.adaptive_interruption_active is False
+
+        recognition.on_end_of_agent_speech(ignore_user_transcript_until=time.time())
+        assert recognition.adaptive_interruption_active is True
+    finally:
+        recognition._interruption_ch.close()
+        await _close_test_session(session)
+
+
+async def test_detector_state_switches_interruption_owner() -> None:
+    session = create_session(FakeActions())
+    activity = AgentActivity(MyAgent(), session)
+    audio_recognition = MagicMock()
+    activity._audio_recognition = audio_recognition
+    activity._interruption_by_audio_activity_enabled = False
+    activity._default_interruption_by_audio_activity_enabled = True
+
+    try:
+        activity._on_interruption_state_changed(
+            inference.InterruptionDetectionStateChangedEvent(
+                previous_state="active",
+                state="reconnecting",
+                reason="temporary outage",
+                retry_count=1,
+            )
+        )
+        audio_recognition.set_interruption_detection_available.assert_called_once_with(False)
+        assert activity._interruption_by_audio_activity_enabled is True
+
+        audio_recognition.reset_mock()
+        activity._on_interruption_state_changed(
+            inference.InterruptionDetectionStateChangedEvent(
+                previous_state="reconnecting",
+                state="active",
+                retry_count=1,
+            )
+        )
+        audio_recognition.set_interruption_detection_available.assert_called_once_with(True)
+
+        fallback = Mock()
+        activity._fallback_to_vad_interruption = fallback
+        activity._on_interruption_state_changed(
+            inference.InterruptionDetectionStateChangedEvent(
+                previous_state="reconnecting",
+                state="fallback",
+                reason="retry budget exhausted",
+                retry_count=3,
+            )
+        )
+        fallback.assert_called_once_with()
+    finally:
+        await _close_test_session(session)
+
+
 async def test_vad_fallback_uses_next_vad_inference_event(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -26,6 +26,7 @@ from livekit.agents.inference.interruption import (
     InterruptionHttpStream,
     InterruptionWebSocketStream,
     _AgentSpeechStartedSentinel,
+    _OverlapSpeechEndedSentinel,
     _OverlapSpeechStartedSentinel,
 )
 from livekit.agents.types import APIConnectOptions
@@ -439,6 +440,58 @@ class TestWsLifecycle:
 
 
 class TestWsCacheTimeout:
+    @pytest.mark.asyncio
+    async def test_ignores_inflight_request_after_overlap_ends(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_ws = MagicMock(spec=aiohttp.ClientWebSocketResponse)
+        mock_ws.send_str = AsyncMock()
+        release_send = asyncio.Event()
+
+        async def _send_bytes(*_: object) -> None:
+            await release_send.wait()
+
+        mock_ws.send_bytes = AsyncMock(side_effect=_send_bytes)
+        mock_ws.closed = False
+        mock_ws.close_code = None
+        mock_ws.close = AsyncMock(return_value=True)
+
+        received_handshake = False
+
+        async def _receive_hang() -> aiohttp.WSMessage:
+            nonlocal received_handshake
+            if not received_handshake:
+                received_handshake = True
+                return aiohttp.WSMessage(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data='{"type":"session.created"}',
+                    extra=None,
+                )
+            await asyncio.sleep(3600)
+            return aiohttp.WSMessage(type=aiohttp.WSMsgType.CLOSED, data=None, extra=None)
+
+        mock_ws.receive = _receive_hang
+        mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+        detector = _create_detector(mock_session, use_proxy=True, inference_timeout=0.05)
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+
+        stream.push_frame(_AgentSpeechStartedSentinel())
+        stream.push_frame(
+            _OverlapSpeechStartedSentinel(speech_duration=0.5, started_at=time.time())
+        )
+        stream.push_frame(_make_audio_frame())
+        try:
+            await asyncio.wait_for(_wait_until(lambda: bool(stream._cache)), timeout=1.0)
+            stream.push_frame(_OverlapSpeechEndedSentinel(ended_at=time.time()))
+            await asyncio.wait_for(_wait_until(lambda: not stream._cache), timeout=1.0)
+            release_send.set()
+            await asyncio.sleep(0.1)
+            assert not stream._cache
+            assert not stream._task.done()
+            assert detector.state == "active"
+        finally:
+            release_send.set()
+            await stream.aclose()
+
     @pytest.mark.asyncio
     async def test_times_out_without_another_audio_frame(self) -> None:
         mock_session = AsyncMock(spec=aiohttp.ClientSession)

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -48,7 +48,11 @@ def _make_audio_frame(*, num_samples: int = 1600, sample_rate: int = 16000) -> r
 
 
 def _create_detector(
-    mock_session: AsyncMock, *, use_proxy: bool, inference_timeout: float = 0.1
+    mock_session: AsyncMock,
+    *,
+    use_proxy: bool,
+    inference_timeout: float = 0.1,
+    detection_interval: float = 0.1,
 ) -> AdaptiveInterruptionDetector:
     detector = AdaptiveInterruptionDetector(
         base_url="http://localhost:9999",
@@ -56,6 +60,7 @@ def _create_detector(
         api_secret="test-secret",
         http_session=mock_session,
         inference_timeout=inference_timeout,
+        detection_interval=detection_interval,
         transport="websocket" if use_proxy else "http",
     )
     return detector
@@ -440,6 +445,22 @@ class TestWsLifecycle:
 
 
 class TestWsCacheTimeout:
+    @pytest.mark.asyncio
+    async def test_request_cache_covers_timeout_window(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        detector = _create_detector(
+            mock_session,
+            use_proxy=True,
+            inference_timeout=0.25,
+            detection_interval=0.01,
+        )
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+
+        try:
+            assert stream._cache.maxsize == 27
+        finally:
+            await stream.aclose()
+
     @pytest.mark.asyncio
     async def test_preserves_current_overlap_detection_after_cache_eviction(self) -> None:
         mock_session = AsyncMock(spec=aiohttp.ClientSession)

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -223,6 +223,38 @@ class TestHttpNonRetryable:
 
 class TestHttpLifecycle:
     @pytest.mark.asyncio
+    async def test_retry_reactivates_stateless_transport(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(
+            side_effect=aiohttp.ClientConnectionError("temporary outage")
+        )
+        mock_session.post.return_value = mock_ctx
+
+        detector = _create_detector(mock_session, use_proxy=False)
+        recovered = asyncio.Event()
+        states: list[InterruptionDetectionStateChangedEvent] = []
+
+        def _on_state(event: InterruptionDetectionStateChangedEvent) -> None:
+            states.append(event)
+            if event.previous_state == "reconnecting" and event.state == "active":
+                recovered.set()
+
+        detector.on("state_changed", _on_state)
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+
+        stream.push_frame(_AgentSpeechStartedSentinel())
+        stream.push_frame(
+            _OverlapSpeechStartedSentinel(speech_duration=0.5, started_at=time.time())
+        )
+        stream.push_frame(_make_audio_frame())
+        try:
+            await asyncio.wait_for(recovered.wait(), timeout=1.0)
+            assert [event.state for event in states] == ["reconnecting", "active"]
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
     async def test_reopens_active_after_stream_close(self) -> None:
         mock_session = AsyncMock(spec=aiohttp.ClientSession)
         detector = _create_detector(mock_session, use_proxy=False)

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -344,6 +344,63 @@ class TestWsHandshake:
             await stream.aclose()
 
 
+class TestWsLifecycle:
+    @pytest.mark.asyncio
+    async def test_end_input_stops_timeout_watcher_and_completes_stream(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_ws = MagicMock(spec=aiohttp.ClientWebSocketResponse)
+        mock_ws.closed = False
+        mock_ws.close_code = None
+        mock_ws.close = AsyncMock(return_value=True)
+        session_close_sent = asyncio.Event()
+
+        async def _send_str(data: str) -> None:
+            if '"session.close"' in data:
+                session_close_sent.set()
+
+        receive_count = 0
+
+        async def _receive() -> aiohttp.WSMessage:
+            nonlocal receive_count
+            receive_count += 1
+            if receive_count == 1:
+                return aiohttp.WSMessage(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data='{"type":"session.created"}',
+                    extra=None,
+                )
+            await session_close_sent.wait()
+            if receive_count == 2:
+                return aiohttp.WSMessage(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data='{"type":"session.closed"}',
+                    extra=None,
+                )
+            return aiohttp.WSMessage(
+                type=aiohttp.WSMsgType.CLOSED,
+                data=None,
+                extra=None,
+            )
+
+        mock_ws.send_str = AsyncMock(side_effect=_send_str)
+        mock_ws.receive = _receive
+        mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+        detector = _create_detector(
+            mock_session,
+            use_proxy=True,
+            inference_timeout=0.05,
+        )
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+
+        stream.end_input()
+        try:
+            await asyncio.wait_for(stream._task, timeout=1.0)
+        finally:
+            await stream.aclose()
+
+        assert session_close_sent.is_set()
+
+
 class TestWsCacheTimeout:
     @pytest.mark.asyncio
     async def test_times_out_without_another_audio_frame(self) -> None:

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -241,12 +241,17 @@ class TestHttpLifecycle:
     async def test_stream_close_preserves_terminal_fallback(self) -> None:
         mock_session = AsyncMock(spec=aiohttp.ClientSession)
         detector = _create_detector(mock_session, use_proxy=False)
+        states = _collect_states(detector)
         stream = detector.stream(conn_options=CONN_OPTIONS)
         detector.fail(RuntimeError("terminal"))
+        detector._set_state("active")
 
         await stream.aclose()
 
         assert detector.state == "fallback"
+        assert [event.state for event in states] == ["fallback"]
+        with pytest.raises(RuntimeError, match="terminally failed"):
+            detector.stream(conn_options=CONN_OPTIONS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -441,6 +441,75 @@ class TestWsLifecycle:
 
 class TestWsCacheTimeout:
     @pytest.mark.asyncio
+    async def test_preserves_current_overlap_detection_after_cache_eviction(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_ws = MagicMock(spec=aiohttp.ClientWebSocketResponse)
+        mock_ws.send_str = AsyncMock()
+        mock_ws.closed = False
+        mock_ws.close_code = None
+        mock_ws.close = AsyncMock(return_value=True)
+        request_sent = asyncio.Event()
+        release_response = asyncio.Event()
+        request_created_at: int | None = None
+
+        async def _send_bytes(data: bytes) -> None:
+            nonlocal request_created_at
+            request_created_at = int.from_bytes(data[:8], byteorder="little")
+            request_sent.set()
+
+        received_handshake = False
+        response_sent = False
+
+        async def _receive() -> aiohttp.WSMessage:
+            nonlocal received_handshake, response_sent
+            if not received_handshake:
+                received_handshake = True
+                return aiohttp.WSMessage(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data='{"type":"session.created"}',
+                    extra=None,
+                )
+            if not response_sent:
+                await release_response.wait()
+                response_sent = True
+                assert request_created_at is not None
+                return aiohttp.WSMessage(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data=(
+                        '{"type":"bargein_detected","created_at":'
+                        f"{request_created_at},"
+                        '"prediction_duration":0.01,"probabilities":[0.9]}'
+                    ),
+                    extra=None,
+                )
+            await asyncio.sleep(3600)
+            return aiohttp.WSMessage(type=aiohttp.WSMsgType.CLOSED, data=None, extra=None)
+
+        mock_ws.send_bytes = AsyncMock(side_effect=_send_bytes)
+        mock_ws.receive = _receive
+        mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+        detector = _create_detector(mock_session, use_proxy=True, inference_timeout=1.0)
+        detected = asyncio.Event()
+        detector.on("overlapping_speech", lambda _: detected.set())
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+
+        stream.push_frame(_AgentSpeechStartedSentinel())
+        stream.push_frame(
+            _OverlapSpeechStartedSentinel(speech_duration=0.5, started_at=time.time())
+        )
+        stream.push_frame(_make_audio_frame())
+        try:
+            await asyncio.wait_for(request_sent.wait(), timeout=1.0)
+            stream._cache.clear()
+            release_response.set()
+            await asyncio.wait_for(detected.wait(), timeout=1.0)
+            assert not stream._cache
+            assert detector.state == "active"
+        finally:
+            release_response.set()
+            await stream.aclose()
+
+    @pytest.mark.asyncio
     async def test_ignores_inflight_request_after_overlap_ends(self) -> None:
         mock_session = AsyncMock(spec=aiohttp.ClientSession)
         mock_ws = MagicMock(spec=aiohttp.ClientWebSocketResponse)

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import aiohttp
@@ -21,6 +22,7 @@ from livekit.agents._exceptions import APIError
 from livekit.agents.inference.interruption import (
     AdaptiveInterruptionDetector,
     InterruptionDetectionError,
+    InterruptionDetectionStateChangedEvent,
     InterruptionHttpStream,
     InterruptionWebSocketStream,
     _AgentSpeechStartedSentinel,
@@ -53,8 +55,8 @@ def _create_detector(
         api_secret="test-secret",
         http_session=mock_session,
         inference_timeout=inference_timeout,
+        transport="websocket" if use_proxy else "http",
     )
-    detector._opts.use_proxy = use_proxy
     return detector
 
 
@@ -64,6 +66,14 @@ def _collect_errors(
     errors: list[InterruptionDetectionError] = []
     detector.on("error", lambda e: errors.append(e))
     return errors
+
+
+def _collect_states(
+    detector: AdaptiveInterruptionDetector,
+) -> list[InterruptionDetectionStateChangedEvent]:
+    states: list[InterruptionDetectionStateChangedEvent] = []
+    detector.on("state_changed", states.append)
+    return states
 
 
 async def _feed_audio_continuously(
@@ -128,7 +138,17 @@ class TestHttpTimeout:
         errors = _collect_errors(detector)
         stream = detector.stream(conn_options=CONN_OPTIONS)
 
-        exc = await _wait_for_stream_failure(stream)
+        stream.push_frame(_AgentSpeechStartedSentinel())
+        stream.push_frame(
+            _OverlapSpeechStartedSentinel(speech_duration=0.5, started_at=time.time())
+        )
+        stream.push_frame(_make_audio_frame())
+        try:
+            with pytest.raises(APIError) as exc_info:
+                await asyncio.wait_for(stream._task, timeout=1.0)
+            exc: Exception | None = exc_info.value
+        finally:
+            await stream.aclose()
 
         assert exc is not None, f"Expected exception, got None. Errors: {errors}"
         assert isinstance(exc, APIError)
@@ -214,6 +234,7 @@ class TestWsConnectionTimeout:
 
         detector = _create_detector(mock_session, use_proxy=True)
         errors = _collect_errors(detector)
+        states = _collect_states(detector)
         stream = detector.stream(conn_options=CONN_OPTIONS)
 
         exc = await _wait_for_stream_failure(stream)
@@ -223,13 +244,16 @@ class TestWsConnectionTimeout:
 
         recoverable_errors = [e for e in errors if e.recoverable]
         unrecoverable_errors = [e for e in errors if not e.recoverable]
-        assert len(recoverable_errors) == 0
+        assert len(recoverable_errors) == MAX_RETRY
         assert len(unrecoverable_errors) == 1
+        assert states[0].state == "reconnecting"
+        assert len([event for event in states if event.state == "reconnecting"]) == MAX_RETRY
+        assert states[-1].state in ("fallback", "closed")
 
 
 class TestWsConnection429:
     @pytest.mark.asyncio
-    async def test_immediate_unrecoverable(self) -> None:
+    async def test_retries_then_emits_unrecoverable(self) -> None:
         mock_session = AsyncMock(spec=aiohttp.ClientSession)
         mock_session.ws_connect = AsyncMock(
             side_effect=aiohttp.ClientResponseError(
@@ -249,16 +273,54 @@ class TestWsConnection429:
         assert exc is not None
         assert isinstance(exc, APIError)
 
-        # 429 -> APIStatusError(retryable=False) so no retries, immediate unrecoverable
         recoverable_errors = [e for e in errors if e.recoverable]
         unrecoverable_errors = [e for e in errors if not e.recoverable]
-        assert len(recoverable_errors) == 0
+        assert len(recoverable_errors) == MAX_RETRY
         assert len(unrecoverable_errors) == 1
+
+
+class TestWsHandshake:
+    @pytest.mark.asyncio
+    async def test_becomes_active_only_after_session_created(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_ws = MagicMock(spec=aiohttp.ClientWebSocketResponse)
+        mock_ws.send_str = AsyncMock()
+        mock_ws.closed = False
+        mock_ws.close_code = None
+        mock_ws.close = AsyncMock(return_value=True)
+        responses = [
+            aiohttp.WSMessage(
+                type=aiohttp.WSMsgType.TEXT,
+                data='{"type":"session.created"}',
+                extra=None,
+            )
+        ]
+
+        async def _receive() -> aiohttp.WSMessage:
+            if responses:
+                return responses.pop()
+            await asyncio.sleep(3600)
+            raise AssertionError("unreachable")
+
+        mock_ws.receive = _receive
+        mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+        detector = _create_detector(mock_session, use_proxy=True)
+        states = _collect_states(detector)
+
+        assert detector.state == "connecting"
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+        try:
+            await asyncio.wait_for(
+                _wait_until(lambda: detector.state == "active"), timeout=1.0
+            )
+            assert [event.state for event in states] == ["active"]
+        finally:
+            await stream.aclose()
 
 
 class TestWsCacheTimeout:
     @pytest.mark.asyncio
-    async def test_retries_then_emits_unrecoverable(self) -> None:
+    async def test_times_out_without_another_audio_frame(self) -> None:
         mock_session = AsyncMock(spec=aiohttp.ClientSession)
 
         inference_timeout = 0.05
@@ -274,7 +336,17 @@ class TestWsCacheTimeout:
 
             mock_ws.send_bytes = _slow_send_bytes
 
+            received_handshake = False
+
             async def _receive_hang() -> aiohttp.WSMessage:
+                nonlocal received_handshake
+                if not received_handshake:
+                    received_handshake = True
+                    return aiohttp.WSMessage(
+                        type=aiohttp.WSMsgType.TEXT,
+                        data='{"type":"session.created"}',
+                        extra=None,
+                    )
                 await asyncio.sleep(3600)
                 return aiohttp.WSMessage(type=aiohttp.WSMsgType.CLOSED, data=None, extra=None)
 
@@ -288,14 +360,32 @@ class TestWsCacheTimeout:
             mock_session, use_proxy=True, inference_timeout=inference_timeout
         )
         errors = _collect_errors(detector)
-        stream = detector.stream(conn_options=CONN_OPTIONS)
+        # A zero retry budget makes the assertion about the independent timeout
+        # deterministic: no second audio frame is needed to discover the failure.
+        stream = detector.stream(
+            conn_options=APIConnectOptions(max_retry=0, retry_interval=0.0, timeout=1.0)
+        )
 
-        exc = await _wait_for_stream_failure(stream)
+        stream.push_frame(_AgentSpeechStartedSentinel())
+        stream.push_frame(
+            _OverlapSpeechStartedSentinel(speech_duration=0.5, started_at=time.time())
+        )
+        stream.push_frame(_make_audio_frame())
+        try:
+            with pytest.raises(APIError) as exc_info:
+                await asyncio.wait_for(stream._task, timeout=1.0)
+            exc: Exception | None = exc_info.value
+        finally:
+            await stream.aclose()
 
         assert exc is not None
         assert isinstance(exc, APIError)
 
-        recoverable_errors = [e for e in errors if e.recoverable]
         unrecoverable_errors = [e for e in errors if not e.recoverable]
-        assert len(recoverable_errors) == 0
         assert len(unrecoverable_errors) == 1
+        assert "timed out" in str(unrecoverable_errors[0].error)
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    while not predicate():
+        await asyncio.sleep(0)

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -221,6 +221,34 @@ class TestHttpNonRetryable:
         assert len(unrecoverable_errors) == 1
 
 
+class TestHttpLifecycle:
+    @pytest.mark.asyncio
+    async def test_reopens_active_after_stream_close(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        detector = _create_detector(mock_session, use_proxy=False)
+
+        first_stream = detector.stream(conn_options=CONN_OPTIONS)
+        await first_stream.aclose()
+        assert detector.state == "closed"
+
+        second_stream = detector.stream(conn_options=CONN_OPTIONS)
+        try:
+            assert detector.state == "active"
+        finally:
+            await second_stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_stream_close_preserves_terminal_fallback(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        detector = _create_detector(mock_session, use_proxy=False)
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+        detector.fail(RuntimeError("terminal"))
+
+        await stream.aclose()
+
+        assert detector.state == "fallback"
+
+
 # ---------------------------------------------------------------------------
 # WebSocket stream tests
 # ---------------------------------------------------------------------------
@@ -310,9 +338,7 @@ class TestWsHandshake:
         assert detector.state == "connecting"
         stream = detector.stream(conn_options=CONN_OPTIONS)
         try:
-            await asyncio.wait_for(
-                _wait_until(lambda: detector.state == "active"), timeout=1.0
-            )
+            await asyncio.wait_for(_wait_until(lambda: detector.state == "active"), timeout=1.0)
             assert [event.state for event in states] == ["active"]
         finally:
             await stream.aclose()

--- a/tests/test_room_audio_output_fade.py
+++ b/tests/test_room_audio_output_fade.py
@@ -7,8 +7,6 @@ queue content as a cosine ramp instead of cutting mid-phoneme.
 
 from __future__ import annotations
 
-import asyncio
-
 import numpy as np
 import pytest
 
@@ -41,7 +39,9 @@ class _FakeAudioSource:
         return None
 
 
-def _make_output(monkeypatch, *, fade_out_ms: int) -> tuple[_ParticipantAudioOutput, _FakeAudioSource]:
+def _make_output(
+    monkeypatch, *, fade_out_ms: int
+) -> tuple[_ParticipantAudioOutput, _FakeAudioSource]:
     monkeypatch.setattr(output_module.rtc, "AudioSource", _FakeAudioSource)
     out = _ParticipantAudioOutput(
         room=object(),  # unused by the paths under test


### PR DESCRIPTION
## 배경

Acoustic barge-in endpoint의 WebSocket 연결이 지연되거나 통화 중 끊기면 adaptive interruption detector가 준비되지 않은 상태에서도 transcript를 보류하고 VAD 기반 interruption이 비활성화될 수 있었습니다. 이 경우 사용자가 말해도 agent 발화가 끊기지 않는 실패 모드가 생길 수 있습니다.

## 설계 원칙

- Acoustic detector가 `active`일 때만 조기 interruption 판단을 소유합니다.
- `connecting`, `reconnecting`, `fallback`에서는 기존 VAD + Main STT 경로가 안전망을 소유합니다.
- 재연결은 LiveKit SDK가 관리하며, 현재 통화에서 재시도가 소진되면 terminal fallback으로 전환합니다.
- 다음 통화는 새로운 detector를 만들기 때문에 Acoustic 연결을 다시 시도합니다.
- dynamic interruption 동작은 이번 범위에서 변경하지 않습니다.

## 주요 변경

- `AdaptiveInterruptionDetector`에 명시적 transport 선택과 연결 상태 이벤트를 추가했습니다.
- WebSocket `session.created` 응답을 받은 뒤에만 detector를 `active`로 전환합니다.
- 연결 timeout, 429, 통화 중 오류에 대해 bounded retry와 terminal fallback을 지원합니다.
- HTTP transport는 handshake가 없으므로 retry backoff가 끝나 새 요청을 받을 수 있는 시점에 `active`로 복귀합니다.
- 추론 응답이 오지 않는 경우를 감지하는 watchdog을 추가했습니다.
- 종료된 overlap의 WS 요청 cache를 즉시 폐기하고, 현재 cache에 존재하는 요청의 응답만 반영합니다. 늦은 send/response가 다음 overlap에 섞이거나 정상 backchannel을 timeout 장애로 오판하지 않습니다.
- detector가 비활성 상태가 되면 보류 중인 transcript를 Main STT 경로로 flush하고 VAD interruption을 복원합니다.
- Agent 생성 시 public `interruption_detection` 계약으로 detector를 전달할 수 있게 했습니다.
- overlap 기반 pause/trim과 ignore-word 경계를 SDK 내부의 단일 소유 지점으로 정리했습니다.
- 정상적으로 닫힌 stream은 detector lifecycle 안에서 재사용할 수 있고, terminal `fallback`은 늦은 handshake나 새 stream 생성으로도 `active`가 되지 않도록 latch했습니다.
- Adaptive stream close timeout은 `AudioRecognition` 한 곳에서 모든 detector에 적용하여 adopter별 wrapper가 필요 없게 했습니다.

## 상태 전이

| 상태 | interruption 소유자 | 다음 동작 |
|---|---|---|
| `connecting` | VAD + Main STT | 초기 연결 대기 |
| `active` | Acoustic detector | 정상 추론 |
| `reconnecting` | VAD + Main STT | 제한된 재연결 |
| `fallback` | VAD + Main STT | 현재 통화에서 Acoustic 중단 |
| `closed` | 없음 | stream 없음; 정상 재사용 시 transport에 따라 `connecting` 또는 `active` |

HTTP는 연결 handshake가 없는 stateless transport입니다. 따라서 retry backoff 동안에는 `reconnecting`으로 VAD가 소유하고, backoff가 끝나 `_run()`이 다시 요청을 받을 준비가 되면 `active`를 알립니다. 상위 계층은 agent 발화 중간에 Acoustic을 갑자기 다시 켜지 않고 다음 안전한 발화 경계에서 소유권을 전환합니다.

## reduce-entropy 정리

- 연결 lifecycle 상태는 detector loop만 저장합니다. `AudioRecognition`은 readiness를 detector 상태에서 파생하며 별도 ready boolean을 저장하지 않습니다.
- bounded stream close는 `AudioRecognition` 한 곳이 소유합니다.
- WS 요청은 send 시 한 번만 cache에 등록되고, receive는 기존 cache entry만 갱신합니다.
- agent-server의 전용 stream wrapper와 파생 VAD active/pending boolean은 선행 adoption PR에서 삭제했습니다.
- 현재 diff: 891 additions / 123 deletions, net +768 lines.
- agent-server adoption PR의 net -917과 합산하면 두 PR 전체는 net -149 lines입니다.

## 자동 리뷰 반영

- HTTP stream 재사용 시 `closed -> active` 복원
- terminal `fallback`을 stream close나 늦은 handshake가 덮지 못하도록 latch
- 정상 WebSocket close 시 timeout watcher 종료
- retryable HTTP 오류 뒤 `reconnecting`에 영구 고착되는 문제 수정
- overlap 종료 뒤 stale WS cache가 정상 응답을 timeout으로 오판하는 문제 수정
- send 완료와 overlap 종료가 경합해도 cache entry가 다시 살아나지 않도록 요청 등록 순서와 응답 갱신 계약 정리
- cache에서 밀려난 현재 overlap 응답은 monotonic generation fence로 복원하고 이전 overlap의 늦은 응답은 차단
- request cache를 inference timeout window에 맞춰 sizing해 continuous overlap에서도 watchdog deadline 보존

## 검증

- `tests/test_agent_session.py`
- `livekit-agents/tests/test_backchannel_latency.py`
- `tests/test_interruption/test_interruption_failover.py`
- 위 묶음: 69 passed
- failover 파일: 14 passed
- HTTP `reconnecting -> active` 회귀 테스트 통과
- WS in-flight send 중 overlap 종료 및 watchdog 비오작동 회귀 테스트 통과
- `mypy -p livekit.agents`: 188 source files, no issues
- 전체 변경 파일 Ruff check 및 format check 통과
- Python 3.10/3.13 type-check CI 통과
- Release gate 통과

## 배포 및 롤백

이 PR은 현재 agent-server가 고정한 `fix/ignore-word-final-keeps-pause` 브랜치를 base로 하는 stacked PR입니다. agent-server PR #1029는 이 PR의 현재 HEAD `28257883849affc0aa83fc72f0a6de3d8e0ad230`을 정확히 고정합니다.

문제 발생 시 agent-server의 LiveKit pin과 adoption commit을 기존 `0cec16fcabaca28b7c4373e8cef3665bebd46210` 기준으로 함께 되돌립니다. DB schema나 영구 데이터 변환은 없습니다.

## 범위 제외

- dynamic interruption 제거
- Acoustic endpoint의 다중 replica/HA 구성
- endpoint 자체의 모델 또는 배포 구조 변경
- protocol version negotiation


