### PR TITLE
fix(voice): VAD 시작점 이전 acoustic pre-roll을 보존

### DIFF
--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -588,7 +588,8 @@ class InterruptionStreamBase(ABC):
             self._accumulated_samples = 0
             await self._num_requests.set(0)
 
-            self._audio_buffer.reset()
+            # Keep customer PCM across agent boundaries so the next overlap can
+            # recover its VAD-onset prefix from the existing ring buffer.
             self._cache.clear()
             self._user_speech_span = None
 
@@ -608,23 +609,35 @@ class InterruptionStreamBase(ABC):
                     self._overlap_started = True
                     self._accumulated_samples = 0
                     self._overlap_count += 1
-                    # include the audio prefix in the window and
-                    # only shift (remove leading silence) when the first overlap speech started
-                    # otherwise, keep the existing data
-                    if self._overlap_count == 1:
-                        shift_size = max(
-                            0,
-                            len(self._audio_buffer)
-                            - (
-                                int(input_frame._speech_duration * self._sample_rate)
-                                + self._prefix_size
-                            ),
-                        )
-                        self._audio_buffer.shift(shift_size)
-                    logger.trace(
+                    # Re-anchor every overlap. Otherwise a later overlap can include stale
+                    # audio from an earlier attempt and produce a false interruption.
+                    buffer_samples_before_trim = len(self._audio_buffer)
+                    speech_samples = int(input_frame._speech_duration * self._sample_rate)
+                    shift_size = max(
+                        0,
+                        buffer_samples_before_trim - (speech_samples + self._prefix_size),
+                    )
+                    self._audio_buffer.shift(shift_size)
+                    prefix_samples_available = max(
+                        0,
+                        min(
+                            self._prefix_size,
+                            buffer_samples_before_trim - speech_samples,
+                        ),
+                    )
+                    logger.debug(
                         "overlap speech started, starting interruption inference",
                         extra={
                             "overlap_count": self._overlap_count,
+                            "buffer_samples_before_trim": buffer_samples_before_trim,
+                            "buffer_samples_after_trim": len(self._audio_buffer),
+                            "speech_samples": speech_samples,
+                            "prefix_samples_target": self._prefix_size,
+                            "prefix_samples_available": prefix_samples_available,
+                            "prefix_underflow_samples": (
+                                self._prefix_size - prefix_samples_available
+                            ),
+                            "shift_size": shift_size,
                         },
                     )
                     self._cache.clear()
@@ -653,10 +666,14 @@ class InterruptionStreamBase(ABC):
                     self._accumulated_samples = 0
                     self._overlap_started_at = None
                     # we don't clear the cache here since responses might be in flight
-                case rtc.AudioFrame() if self._agent_speech_started:
+                case rtc.AudioFrame():
+                    # Capture continuously; agent/overlap state gates inference only.
                     samples_written = self._audio_buffer.push_frame(input_frame)
+                    if not self._agent_speech_started or not self._overlap_started:
+                        continue
+
                     self._accumulated_samples += samples_written
-                    if self._accumulated_samples >= self._batch_size and self._overlap_started:
+                    if self._accumulated_samples >= self._batch_size:
                         output_ch.send_nowait(self._audio_buffer.read())
                         self._accumulated_samples = 0
 
@@ -735,7 +752,15 @@ class InterruptionHttpStream(InterruptionStreamBase):
                     is_interruption=resp.is_bargein,
                 )
                 if entry.is_interruption and self._overlap_started:
-                    logger.debug("user interruption detected")
+                    logger.debug(
+                        "user interruption detected",
+                        extra={
+                            "input_samples": (
+                                len(entry.speech_input) if entry.speech_input is not None else None
+                            ),
+                            "probability": entry.get_probability(),
+                        },
+                    )
                     if self._user_speech_span:
                         self._update_user_speech_span(self._user_speech_span, entry)
                         self._user_speech_span = None
@@ -1016,6 +1041,11 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                             logger.debug(
                                 "interruption detected",
                                 extra={
+                                    "input_samples": (
+                                        len(entry.speech_input)
+                                        if entry.speech_input is not None
+                                        else None
+                                    ),
                                     "total_duration": entry.get_total_duration(),
                                     "prediction_duration": entry.get_prediction_duration(),
                                     "detection_delay": entry.get_detection_delay(),
@@ -1048,6 +1078,11 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                             logger.trace(
                                 "interruption inference done",
                                 extra={
+                                    "input_samples": (
+                                        len(entry.speech_input)
+                                        if entry.speech_input is not None
+                                        else None
+                                    ),
                                     "total_duration": entry.get_total_duration(),
                                     "prediction_duration": entry.get_prediction_duration(),
                                     "probability": entry.get_probability(),

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -342,6 +342,24 @@ class AudioRecognition:
 
         if self.adaptive_interruption_active:
             self._interruption_ch.send_nowait(_AgentSpeechStartedSentinel())  # type: ignore[union-attr]
+            # VAD may already be inside a user speech segment when playout starts.
+            if self._vad_speech_started and self._speech_start_time is not None:
+                speech_duration = max(0.0, started_at - self._speech_start_time)
+                logger.debug(
+                    "agent speech started during active user VAD; continuing overlap inference",
+                    extra={
+                        "agent_speech_started_at": started_at,
+                        "vad_speech_started_at": self._speech_start_time,
+                        "speech_duration": speech_duration,
+                    },
+                )
+                self._interruption_ch.send_nowait(  # type: ignore[union-attr]
+                    _OverlapSpeechStartedSentinel(
+                        speech_duration=speech_duration,
+                        started_at=started_at,
+                        user_speaking_span=self._session._user_speaking_span,
+                    )
+                )
 
     def on_end_of_agent_speech(self, *, ignore_user_transcript_until: float) -> None:
         self._cancel_backchannel_boundary()

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -356,7 +356,9 @@ class AudioRecognition:
                 self._interruption_ch.send_nowait(  # type: ignore[union-attr]
                     _OverlapSpeechStartedSentinel(
                         speech_duration=speech_duration,
-                        started_at=started_at,
+                        # Preserve the current user turn's transcript boundary;
+                        # agent playout may begin in the middle of this VAD segment.
+                        started_at=self._speech_start_time,
                         user_speaking_span=self._session._user_speaking_span,
                     )
                 )

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -343,7 +343,7 @@ class AudioRecognition:
         if self.adaptive_interruption_active:
             self._interruption_ch.send_nowait(_AgentSpeechStartedSentinel())  # type: ignore[union-attr]
             # VAD may already be inside a user speech segment when playout starts.
-            if self._vad_speech_started and self._speech_start_time is not None:
+            if self._speaking and self._vad_speech_started and self._speech_start_time is not None:
                 speech_duration = max(0.0, started_at - self._speech_start_time)
                 logger.debug(
                     "agent speech started during active user VAD; continuing overlap inference",

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -11,6 +11,7 @@ import pytest
 from livekit.agents import (
     Agent,
     AgentFalseInterruptionEvent,
+    AgentSession,
     AgentStateChangedEvent,
     ConversationItemAddedEvent,
     FlushSentinel,
@@ -22,6 +23,10 @@ from livekit.agents import (
     function_tool,
     inference,
     vad,
+)
+from livekit.agents.inference.interruption import (
+    _AgentSpeechStartedSentinel,
+    _OverlapSpeechStartedSentinel,
 )
 from livekit.agents.llm import (
     FunctionToolCall,
@@ -762,6 +767,86 @@ async def test_backchannel_boundary_suppresses_start_boundary_backchannel() -> N
         await recognition._on_overlap_speech_event(_interruption_event())
         assert len(hooks.interruptions) == 2
     finally:
+        await _close_test_session(session)
+
+
+def _active_adaptive_recognition() -> tuple[AgentSession, AudioRecognition]:
+    session = create_session(FakeActions())
+    detector = MagicMock()
+    detector.state = "active"
+    recognition = AudioRecognition(
+        session,
+        hooks=_TestRecognitionHooks(),
+        endpointing=BaseEndpointing(min_delay=0.1, max_delay=1.0),
+        stt=None,
+        vad=MagicMock(),
+        interruption_detection=detector,
+        turn_detection="vad",
+    )
+    recognition._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
+    return session, recognition
+
+
+async def test_agent_start_connects_vad_speech_that_started_before_playout() -> None:
+    session, recognition = _active_adaptive_recognition()
+    recognition._vad_speech_started = True
+    recognition._speech_start_time = 100.0
+
+    try:
+        recognition.on_start_of_agent_speech(started_at=100.7)
+
+        agent_started = recognition._interruption_ch.recv_nowait()
+        overlap_started = recognition._interruption_ch.recv_nowait()
+        assert isinstance(agent_started, _AgentSpeechStartedSentinel)
+        assert isinstance(overlap_started, _OverlapSpeechStartedSentinel)
+        assert overlap_started._speech_duration == pytest.approx(0.7)
+        assert overlap_started._started_at == 100.7
+        assert overlap_started._user_speaking_span is session._user_speaking_span
+        assert recognition._interruption_ch.empty()
+    finally:
+        recognition._interruption_ch.close()
+        await _close_test_session(session)
+
+
+async def test_agent_start_does_not_connect_vad_speech_that_already_ended() -> None:
+    session, recognition = _active_adaptive_recognition()
+    recognition._vad_speech_started = False
+    recognition._speech_start_time = 100.0
+
+    try:
+        recognition.on_start_of_agent_speech(started_at=100.7)
+
+        assert isinstance(
+            recognition._interruption_ch.recv_nowait(),
+            _AgentSpeechStartedSentinel,
+        )
+        assert recognition._interruption_ch.empty()
+    finally:
+        recognition._interruption_ch.close()
+        await _close_test_session(session)
+
+
+async def test_vad_start_after_agent_uses_normal_overlap_path_once() -> None:
+    session, recognition = _active_adaptive_recognition()
+
+    try:
+        recognition.on_start_of_agent_speech(started_at=100.0)
+        assert isinstance(
+            recognition._interruption_ch.recv_nowait(),
+            _AgentSpeechStartedSentinel,
+        )
+
+        recognition.on_start_of_speech(
+            started_at=100.2,
+            speech_duration=0.05,
+        )
+        overlap_started = recognition._interruption_ch.recv_nowait()
+        assert isinstance(overlap_started, _OverlapSpeechStartedSentinel)
+        assert overlap_started._speech_duration == 0.05
+        assert overlap_started._started_at == 100.2
+        assert recognition._interruption_ch.empty()
+    finally:
+        recognition._interruption_ch.close()
         await _close_test_session(session)
 
 

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -801,7 +801,7 @@ async def test_agent_start_connects_vad_speech_that_started_before_playout() -> 
         assert isinstance(agent_started, _AgentSpeechStartedSentinel)
         assert isinstance(overlap_started, _OverlapSpeechStartedSentinel)
         assert overlap_started._speech_duration == pytest.approx(0.7)
-        assert overlap_started._started_at == 100.7
+        assert overlap_started._started_at == 100.0
         assert overlap_started._user_speaking_span is session._user_speaking_span
         assert recognition._interruption_ch.empty()
     finally:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -789,6 +789,7 @@ def _active_adaptive_recognition() -> tuple[AgentSession, AudioRecognition]:
 
 async def test_agent_start_connects_vad_speech_that_started_before_playout() -> None:
     session, recognition = _active_adaptive_recognition()
+    recognition._speaking = True
     recognition._vad_speech_started = True
     recognition._speech_start_time = 100.0
 
@@ -811,6 +812,26 @@ async def test_agent_start_connects_vad_speech_that_started_before_playout() -> 
 async def test_agent_start_does_not_connect_vad_speech_that_already_ended() -> None:
     session, recognition = _active_adaptive_recognition()
     recognition._vad_speech_started = False
+    recognition._speech_start_time = 100.0
+
+    try:
+        recognition.on_start_of_agent_speech(started_at=100.7)
+
+        assert isinstance(
+            recognition._interruption_ch.recv_nowait(),
+            _AgentSpeechStartedSentinel,
+        )
+        assert recognition._interruption_ch.empty()
+    finally:
+        recognition._interruption_ch.close()
+        await _close_test_session(session)
+
+
+async def test_agent_start_does_not_connect_stale_vad_segment_after_stt_eos() -> None:
+    session, recognition = _active_adaptive_recognition()
+    recognition._turn_detection_mode = "stt"
+    recognition._speaking = False
+    recognition._vad_speech_started = True
     recognition._speech_start_time = 100.0
 
     try:

--- a/tests/test_interruption/test_interruption_preroll.py
+++ b/tests/test_interruption/test_interruption_preroll.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from time import perf_counter_ns
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import numpy as np
+import pytest
+
+from livekit import rtc
+from livekit.agents.inference.interruption import (
+    AdaptiveInterruptionDetector,
+    InterruptionResponse,
+    _AgentSpeechEndedSentinel,
+    _AgentSpeechStartedSentinel,
+    _OverlapSpeechStartedSentinel,
+)
+
+pytestmark = pytest.mark.unit
+
+_SAMPLE_RATE = 16000
+
+
+def _frame(samples: list[int]) -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=np.asarray(samples, dtype=np.int16).tobytes(),
+        sample_rate=_SAMPLE_RATE,
+        num_channels=1,
+        samples_per_channel=len(samples),
+    )
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    while not predicate():
+        await asyncio.sleep(0)
+
+
+def _detector() -> AdaptiveInterruptionDetector:
+    return AdaptiveInterruptionDetector(
+        base_url="http://localhost:9999",
+        api_key="test-key",
+        api_secret="test-secret",
+        http_session=AsyncMock(spec=aiohttp.ClientSession),
+        audio_prefix_duration=4 / _SAMPLE_RATE,
+        detection_interval=1 / _SAMPLE_RATE,
+        transport="http",
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_overlap_contains_pre_agent_pcm_without_early_inference(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="livekit.agents")
+    detector = _detector()
+    stream = detector.stream()
+    predict = AsyncMock(
+        return_value=InterruptionResponse(
+            created_at=perf_counter_ns(),
+            is_bargein=False,
+            prediction_duration=0.001,
+            probabilities=np.asarray([0.1], dtype=np.float32),
+        )
+    )
+    with patch.object(stream, "predict", predict):
+        try:
+            # Four prefix samples and four user-speech samples arrive before agent playout.
+            stream.push_frame(_frame([1, 2, 3, 4]))
+            stream.push_frame(_frame([10, 11, 12, 13]))
+            await _wait_until(lambda: len(stream._audio_buffer) == 8)
+            predict.assert_not_awaited()
+
+            stream.push_frame(_AgentSpeechStartedSentinel())
+            await _wait_until(lambda: stream._agent_speech_started)
+            np.testing.assert_array_equal(
+                stream._audio_buffer.read(),
+                [1, 2, 3, 4, 10, 11, 12, 13],
+            )
+            predict.assert_not_awaited()
+
+            stream.push_frame(
+                _OverlapSpeechStartedSentinel(
+                    speech_duration=4 / _SAMPLE_RATE,
+                    started_at=100.0,
+                )
+            )
+            stream.push_frame(_frame([20, 21]))
+            await _wait_until(lambda: predict.await_count == 1)
+
+            assert predict.await_args is not None
+            model_input = predict.await_args.args[0]
+            np.testing.assert_array_equal(
+                model_input,
+                [1, 2, 3, 4, 10, 11, 12, 13, 20, 21],
+            )
+            overlap_log = next(
+                record
+                for record in caplog.records
+                if record.message == "overlap speech started, starting interruption inference"
+            )
+            log_fields = vars(overlap_log)
+            assert log_fields["buffer_samples_before_trim"] == 8
+            assert log_fields["buffer_samples_after_trim"] == 8
+            assert log_fields["prefix_samples_target"] == 4
+            assert log_fields["prefix_samples_available"] == 4
+            assert log_fields["prefix_underflow_samples"] == 0
+        finally:
+            await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_agent_boundaries_reset_inference_state_but_keep_pcm_history() -> None:
+    detector = _detector()
+    stream = detector.stream()
+
+    try:
+        stream.push_frame(_frame([1, 2, 3]))
+        stream.push_frame(_AgentSpeechStartedSentinel())
+        stream.push_frame(
+            _OverlapSpeechStartedSentinel(
+                speech_duration=2 / _SAMPLE_RATE,
+                started_at=100.0,
+            )
+        )
+        await _wait_until(lambda: stream._overlap_started)
+
+        stream.push_frame(_AgentSpeechEndedSentinel())
+        stream.push_frame(_frame([4, 5]))
+        await _wait_until(lambda: len(stream._audio_buffer) == 5)
+
+        assert not stream._agent_speech_started
+        assert not stream._overlap_started
+        np.testing.assert_array_equal(stream._audio_buffer.read(), [1, 2, 3, 4, 5])
+    finally:
+        await stream.aclose()

--- a/tests/test_interruption/test_interruption_preroll.py
+++ b/tests/test_interruption/test_interruption_preroll.py
@@ -46,7 +46,6 @@ def _detector() -> AdaptiveInterruptionDetector:
         http_session=AsyncMock(spec=aiohttp.ClientSession),
         audio_prefix_duration=4 / _SAMPLE_RATE,
         detection_interval=1 / _SAMPLE_RATE,
-        transport="http",
     )
 
 


### PR DESCRIPTION
## 요약

고객 발화가 에이전트 playout보다 먼저 시작한 경우에도 acoustic barge-in 모델이
**VAD가 추정한 고객 발화 시작점의 앞쪽 pre-roll부터** 판단하도록 수정합니다.

이 PR은 다른 open PR에 의존하지 않습니다.

- base branch: `fix/ignore-word-final-keeps-pause`
- base SHA: `0cec16fcabaca28b7c4373e8cef3665bebd46210`
- head SHA: `ceab08c6b0f8e45d1c5ec9b4f3adc199de9af670`
- 포함 범위: pre-roll 보존, VAD-first overlap 연결, 관련 로그와 회귀 테스트
- 비포함 범위: endpoint fallback, reconnect 정책, timeout 정책, threshold/model 변경

## 문제

관찰된 순서는 다음과 같습니다.

1. 고객이 `"여보세요"`를 먼저 말하기 시작함
2. 약 0.3~0.7초 뒤 에이전트 음성이 재생되기 시작함
3. 기존 stream은 agent speech 경계에서 PCM history를 초기화함
4. 고객 VAD는 이미 시작된 상태라 일반적인 overlap-start 경계도 새로 오지 않음
5. acoustic 모델이 발화 앞부분과 onset 이전 문맥이 부족한 입력을 받음
6. 동일한 `"여보세요"`라도 평소보다 높은 점수가 나와 잠깐 pause 후 resume될 수 있음

과거 대상 콜의 raw model-input PCM은 보존되어 있지 않아 과거 개별 요청의 byte 단위
입력을 직접 증명할 수는 없습니다. 다만 기존 코드의 capture gate와 agent-start
reset이 동일한 손실 구조를 만들고 있었고, 이 PR의 테스트는 해당 이벤트 순서를 exact
PCM 배열로 재현합니다.

## 변경 내용

### 1. 기존 3초 PCM ring을 연속 capture에 사용

`InterruptionStreamBase`가 agent speaking 여부와 무관하게 고객 PCM을 기존
`AudioArrayBuffer`에 기록합니다.

- 새 buffer를 만들지 않음
- 기존 3초 bounded ring을 그대로 사용
- agent speech 시작/종료 시 inference 상태만 초기화하고 PCM history는 유지
- inference와 network request는 `agent_speech_started && overlap_started`일 때만 실행

따라서 overlap이 없는 동안 모델 요청은 늘지 않습니다.

### 2. VAD-first 순서를 실제 overlap으로 연결

agent playout이 시작될 때 고객 VAD segment가 이미 활성 상태이면 기존 interruption
channel로 `_OverlapSpeechStartedSentinel`을 정확히 한 번 보냅니다.

- trim 기준: VAD가 추정한 고객 발화 시작점
- 모델 입력 범위: `[VAD 발화 시작점 - 1초, 현재]`에서 ring에 남아 있는 구간
- overlap/transcript 경계: 기존 고객 VAD 발화 시작점
- agent playout 시작 시점: 별도 구조화 로그에 보존
- 별도 ordering flag 없이 기존 `_speaking`, `_vad_speech_started`,
  `_speech_start_time`을 사용
- STT EOU 뒤 stale VAD 상태는 `_speaking=false` 조건으로 제외

### 3. 매 overlap의 buffer 경계를 fork가 직접 소유

현재 agent-server가 수행하던 every-overlap trim과 같은 동작을 fork의 원래
`_forward_data` 구현 안에 둡니다. 첫 고객 발화가 무시된 뒤 두 번째 발화가 와도 이전
tail이 섞이지 않습니다.

agent-server 적용 PR에서는 `_forward_data` 전체를 복제하던 class-level monkey
patch를 삭제합니다. 결과적으로 PCM capture와 trim의 구현 주체가 fork 한 곳으로
줄어듭니다.

### 4. 운영 관측 필드

기존 구조화 로그에 다음 숫자를 남깁니다.

- `buffer_samples_before_trim`
- `buffer_samples_after_trim`
- `speech_samples`
- `prefix_samples_target`
- `prefix_samples_available`
- `prefix_underflow_samples`
- `shift_size`
- `input_samples`

raw PCM과 transcript는 로그에 추가하지 않습니다.

## reduce-entropy 관점

- 새 ring buffer 없음
- 새 timer/task/queue 없음
- 새 protocol 또는 feature flag 없음
- `"여보세요"` 같은 phrase 예외 없음
- threshold/min-frame 의미 변경 없음
- agent-server와 fork의 중복 `_forward_data` 구현 제거

즉, 기존 ring의 capture 시점과 기존 event ordering만 바로잡습니다.

## 검증

독립 base `0cec16fc` 기준 로컬 검증 결과입니다.

- exact PCM 및 event-order 테스트: **6 passed**
  - agent 시작 전 PCM이 첫 모델 입력에 포함됨
  - overlap 전 model request가 발생하지 않음
  - agent 경계에서 inference state만 초기화되고 PCM은 유지됨
  - VAD-first, VAD-ended, stale VAD, agent-first 순서 검증
  - VAD-first overlap이 agent 전 같은 고객 turn의 transcript 경계를 보존함
- interruption/failover/buffer/session 회귀 묶음: **87 passed**
- 변경 파일 Ruff format/check: 통과
- `git diff --check`: 통과

전체 저장소 Ruff CI는 base SHA `0cec16fc`에 이미 존재하는
`tests/test_room_audio_output_fade.py:10`의 미사용 `asyncio` import 1건으로
실패합니다. base PR #36의 Ruff도 같은 오류로 실패 중입니다. 이번 문제와 무관한
변경을 섞지 않기 위해 해당 파일은 이 PR에서 수정하지 않았습니다. Python 3.10/3.13
type-check는 모두 통과했습니다.

## 리소스 영향

- 메모리 증가 없음: 기존 최대 약 96KB/stream의 3초 ring 재사용
- 모델/network 요청 증가 없음: 실제 overlap 전 inference gate 유지
- 추가 비용: agent가 말하지 않는 동안에도 bounded ring을 위한 frame copy/resample

60초 입력 microbenchmark 중앙값은 sample rate별 약 32~50ms CPU로, 실시간 1초당
1ms 미만이었습니다. 실제 운영 영향은 canary에서 CPU, RSS, event-loop lag로 다시
확인합니다.

## 배포와 롤백

1. 이 fork PR merge
2. agent-server 적용 PR에서 이 PR의 최종 SHA pin
3. 기존 acoustic allowlist 범위에 canary 배포
4. prefix underflow, input samples, pause/resume 비율과 리소스 지표 확인

문제가 생기면 agent-server의 `livekit-agents` pin을 독립 base
`0cec16fcabaca28b7c4373e8cef3665bebd46210`으로 되돌립니다. DB/config migration은
없습니다.

## 리뷰 포인트

- agent speech 전 PCM이 VAD onset 기준으로 정확히 포함되는가
- overlap 전 inference/network request가 발생하지 않는가
- VAD-first overlap이 정확히 한 번만 연결되는가
- stale VAD를 새 overlap으로 오인하지 않는가
- 같은 agent 발화의 후속 overlap에 이전 발화 tail이 섞이지 않는가
- 다른 open PR의 commit이나 기능이 ancestry/diff에 포함되지 않았는가
