### PR TITLE
수정: SIGTERM을 event 기반 drain으로 전달

### DIFF
--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -1578,25 +1578,21 @@ def _run_worker(server: AgentServer, args: proto.CliArgs, jupyter: bool = False)
     if args.devmode:
         c = AgentsConsole.get_instance()  # colored logs
 
-    exit_triggered = False
-
-    if not jupyter:
-
-        def _handle_exit(sig: int, frame: FrameType | None) -> None:
-            nonlocal exit_triggered
-            if not exit_triggered:
-                exit_triggered = True
-                raise _ExitCli()
-
-        for sig in HANDLED_SIGNALS:
-            signal.signal(sig, _handle_exit)
-
     _configure_logger(c, args.log_level)
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
     loop.slow_callback_duration = 0.1  # 100ms
+    shutdown_requested = asyncio.Event()
+
+    if not jupyter:
+
+        def _handle_exit(sig: int, frame: FrameType | None) -> None:
+            loop.call_soon_threadsafe(shutdown_requested.set)
+
+        for sig in HANDLED_SIGNALS:
+            signal.signal(sig, _handle_exit)
 
     async def _worker_run(worker: AgentServer) -> None:
         try:
@@ -1614,29 +1610,36 @@ def _run_worker(server: AgentServer, args: proto.CliArgs, jupyter: bool = False)
 
     try:
         main_task = loop.create_task(_worker_run(server), name="worker_main_task_cli")
-        try:
-            loop.run_until_complete(main_task)
-        except _ExitCli:
-            pass
 
-        try:
-            exit_triggered = False  # allow a new _ExitCLI raise
-            if not args.devmode:
-                try:
-                    loop.run_until_complete(server.drain())
-                except asyncio.TimeoutError:
-                    logger.warning("drain timed out, forcing shutdown")
+        async def _wait_for_worker_or_shutdown() -> None:
+            shutdown_task = asyncio.create_task(
+                shutdown_requested.wait(),
+                name="worker_shutdown_signal_cli",
+            )
+            try:
+                done, _ = await asyncio.wait(
+                    {main_task, shutdown_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if main_task in done:
+                    await main_task
+            finally:
+                shutdown_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await shutdown_task
 
-            loop.run_until_complete(server.aclose())
+        loop.run_until_complete(_wait_for_worker_or_shutdown())
 
-            if watch_client:
-                loop.run_until_complete(watch_client.aclose())
-        except _ExitCli:
-            if not jupyter:
-                logger.warning("exiting forcefully")
-                import os
+        if not args.devmode:
+            try:
+                loop.run_until_complete(server.drain())
+            except asyncio.TimeoutError:
+                logger.warning("drain timed out, forcing shutdown")
 
-                os._exit(1)  # TODO(theomonnom): add aclose(force=True) in worker
+        loop.run_until_complete(server.aclose())
+
+        if watch_client:
+            loop.run_until_complete(watch_client.aclose())
     finally:
         if jupyter:
             loop.close()  # close can only be called from the main thread

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -588,7 +588,8 @@ class InterruptionStreamBase(ABC):
             self._accumulated_samples = 0
             await self._num_requests.set(0)
 
-            self._audio_buffer.reset()
+            # Keep customer PCM across agent boundaries so the next overlap can
+            # recover its VAD-onset prefix from the existing ring buffer.
             self._cache.clear()
             self._user_speech_span = None
 
@@ -608,23 +609,35 @@ class InterruptionStreamBase(ABC):
                     self._overlap_started = True
                     self._accumulated_samples = 0
                     self._overlap_count += 1
-                    # include the audio prefix in the window and
-                    # only shift (remove leading silence) when the first overlap speech started
-                    # otherwise, keep the existing data
-                    if self._overlap_count == 1:
-                        shift_size = max(
-                            0,
-                            len(self._audio_buffer)
-                            - (
-                                int(input_frame._speech_duration * self._sample_rate)
-                                + self._prefix_size
-                            ),
-                        )
-                        self._audio_buffer.shift(shift_size)
-                    logger.trace(
+                    # Re-anchor every overlap. Otherwise a later overlap can include stale
+                    # audio from an earlier attempt and produce a false interruption.
+                    buffer_samples_before_trim = len(self._audio_buffer)
+                    speech_samples = int(input_frame._speech_duration * self._sample_rate)
+                    shift_size = max(
+                        0,
+                        buffer_samples_before_trim - (speech_samples + self._prefix_size),
+                    )
+                    self._audio_buffer.shift(shift_size)
+                    prefix_samples_available = max(
+                        0,
+                        min(
+                            self._prefix_size,
+                            buffer_samples_before_trim - speech_samples,
+                        ),
+                    )
+                    logger.debug(
                         "overlap speech started, starting interruption inference",
                         extra={
                             "overlap_count": self._overlap_count,
+                            "buffer_samples_before_trim": buffer_samples_before_trim,
+                            "buffer_samples_after_trim": len(self._audio_buffer),
+                            "speech_samples": speech_samples,
+                            "prefix_samples_target": self._prefix_size,
+                            "prefix_samples_available": prefix_samples_available,
+                            "prefix_underflow_samples": (
+                                self._prefix_size - prefix_samples_available
+                            ),
+                            "shift_size": shift_size,
                         },
                     )
                     self._cache.clear()
@@ -653,10 +666,14 @@ class InterruptionStreamBase(ABC):
                     self._accumulated_samples = 0
                     self._overlap_started_at = None
                     # we don't clear the cache here since responses might be in flight
-                case rtc.AudioFrame() if self._agent_speech_started:
+                case rtc.AudioFrame():
+                    # Capture continuously; agent/overlap state gates inference only.
                     samples_written = self._audio_buffer.push_frame(input_frame)
+                    if not self._agent_speech_started or not self._overlap_started:
+                        continue
+
                     self._accumulated_samples += samples_written
-                    if self._accumulated_samples >= self._batch_size and self._overlap_started:
+                    if self._accumulated_samples >= self._batch_size:
                         output_ch.send_nowait(self._audio_buffer.read())
                         self._accumulated_samples = 0
 
@@ -735,7 +752,15 @@ class InterruptionHttpStream(InterruptionStreamBase):
                     is_interruption=resp.is_bargein,
                 )
                 if entry.is_interruption and self._overlap_started:
-                    logger.debug("user interruption detected")
+                    logger.debug(
+                        "user interruption detected",
+                        extra={
+                            "input_samples": (
+                                len(entry.speech_input) if entry.speech_input is not None else None
+                            ),
+                            "probability": entry.get_probability(),
+                        },
+                    )
                     if self._user_speech_span:
                         self._update_user_speech_span(self._user_speech_span, entry)
                         self._user_speech_span = None
@@ -1016,6 +1041,11 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                             logger.debug(
                                 "interruption detected",
                                 extra={
+                                    "input_samples": (
+                                        len(entry.speech_input)
+                                        if entry.speech_input is not None
+                                        else None
+                                    ),
                                     "total_duration": entry.get_total_duration(),
                                     "prediction_duration": entry.get_prediction_duration(),
                                     "detection_delay": entry.get_detection_delay(),
@@ -1048,6 +1078,11 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                             logger.trace(
                                 "interruption inference done",
                                 extra={
+                                    "input_samples": (
+                                        len(entry.speech_input)
+                                        if entry.speech_input is not None
+                                        else None
+                                    ),
                                     "total_duration": entry.get_total_duration(),
                                     "prediction_duration": entry.get_prediction_duration(),
                                     "probability": entry.get_probability(),

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2267,6 +2267,20 @@ class AgentActivity(RecognitionHooks):
                 # schedule a resume timer if interrupted after end_of_speech
                 self._start_false_interruption_timer(timeout)
 
+        # voxai: an ignore-word final (backchannel like "네") never commits a turn,
+        # so interrupting the paused speech here would leave dead air — no resume
+        # and no reply. Keep the pause and its false-interruption timer alive so
+        # playback resumes instead.
+        if (
+            self._paused_speech is not None
+            and self._session.options.interruption_ignore_words
+            and _matches_ignore_words(
+                ev.alternatives[0].text,
+                self._session.options.interruption_ignore_words,
+            )
+        ):
+            return
+
         self._cancel_speech_pause_task = asyncio.create_task(
             self._cancel_speech_pause(old_task=self._cancel_speech_pause_task)
         )

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -342,6 +342,24 @@ class AudioRecognition:
 
         if self.adaptive_interruption_active:
             self._interruption_ch.send_nowait(_AgentSpeechStartedSentinel())  # type: ignore[union-attr]
+            # VAD may already be inside a user speech segment when playout starts.
+            if self._vad_speech_started and self._speech_start_time is not None:
+                speech_duration = max(0.0, started_at - self._speech_start_time)
+                logger.debug(
+                    "agent speech started during active user VAD; continuing overlap inference",
+                    extra={
+                        "agent_speech_started_at": started_at,
+                        "vad_speech_started_at": self._speech_start_time,
+                        "speech_duration": speech_duration,
+                    },
+                )
+                self._interruption_ch.send_nowait(  # type: ignore[union-attr]
+                    _OverlapSpeechStartedSentinel(
+                        speech_duration=speech_duration,
+                        started_at=started_at,
+                        user_speaking_span=self._session._user_speaking_span,
+                    )
+                )
 
     def on_end_of_agent_speech(self, *, ignore_user_transcript_until: float) -> None:
         self._cancel_backchannel_boundary()

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -356,7 +356,9 @@ class AudioRecognition:
                 self._interruption_ch.send_nowait(  # type: ignore[union-attr]
                     _OverlapSpeechStartedSentinel(
                         speech_duration=speech_duration,
-                        started_at=started_at,
+                        # Preserve the current user turn's transcript boundary;
+                        # agent playout may begin in the middle of this VAD segment.
+                        started_at=self._speech_start_time,
                         user_speaking_span=self._session._user_speaking_span,
                     )
                 )

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -343,7 +343,7 @@ class AudioRecognition:
         if self.adaptive_interruption_active:
             self._interruption_ch.send_nowait(_AgentSpeechStartedSentinel())  # type: ignore[union-attr]
             # VAD may already be inside a user speech segment when playout starts.
-            if self._vad_speech_started and self._speech_start_time is not None:
+            if self._speaking and self._vad_speech_started and self._speech_start_time is not None:
                 speech_duration = max(0.0, started_at - self._speech_start_time)
                 logger.debug(
                     "agent speech started during active user VAD; continuing overlap inference",

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import time
+from collections import deque
 
 from google.protobuf.json_format import MessageToDict
 
@@ -32,6 +34,7 @@ class _ParticipantAudioOutput(io.AudioOutput):
         num_channels: int,
         track_publish_options: rtc.TrackPublishOptions,
         track_name: str = "roomio_audio",
+        fade_out_ms: int = 0,
     ) -> None:
         super().__init__(
             label="RoomIO",
@@ -55,6 +58,19 @@ class _ParticipantAudioOutput(io.AudioOutput):
         self._flush_task: asyncio.Task[None] | None = None
         self._interrupted_event = asyncio.Event()
         self._forwarding_task: asyncio.Task[None] | None = None
+
+        # voxai: fade-stop support. 0 keeps the stock instant clear_queue
+        # behavior bit-for-bit. When >0, a rolling copy of the last captured
+        # audio lets us replay the *dropped* queue content as a short gain
+        # ramp instead of cutting mid-phoneme.
+        self._fade_out_ms = max(0, int(fade_out_ms))
+        self._fade_in_ms = 80
+        self._sample_rate_hz = sample_rate
+        self._num_channels = num_channels
+        self._fade_ring: deque[rtc.AudioFrame] = deque()
+        self._fade_ring_duration = 0.0
+        self._fade_in_remaining = 0  # samples left to ramp in after resume
+        self._fade_tail_active = False
 
         self._pushed_duration: float = 0.0
 
@@ -162,7 +178,10 @@ class _ParticipantAudioOutput(io.AudioOutput):
                 queued_duration += self._audio_buf.recv_nowait().duration
 
             pushed_duration = max(pushed_duration - queued_duration, 0)
-            self._audio_source.clear_queue()
+            if self._fade_out_ms > 0:
+                pushed_duration += await self._play_fade_tail()
+            else:
+                self._audio_source.clear_queue()
             wait_for_playout.cancel()
         else:
             wait_for_interruption.cancel()
@@ -172,11 +191,109 @@ class _ParticipantAudioOutput(io.AudioOutput):
         self._first_frame_event.clear()
         self.on_playback_finished(playback_position=pushed_duration, interrupted=interrupted)
 
+    def _fade_ring_push(self, frame: rtc.AudioFrame) -> None:
+        """Keep a rolling copy of recently captured audio (~2x fade window)."""
+        self._fade_ring.append(frame)
+        self._fade_ring_duration += frame.duration
+        max_duration = self._fade_out_ms / 1000 * 2 + 0.25
+        while self._fade_ring and self._fade_ring_duration > max_duration:
+            self._fade_ring_duration -= self._fade_ring.popleft().duration
+
+    def _apply_fade_in(self, frame: rtc.AudioFrame) -> rtc.AudioFrame:
+        data = bytearray(frame.data)
+        samples = memoryview(data).cast("h")
+        total = int(self._fade_in_ms / 1000 * self._sample_rate_hz)
+        done = total - self._fade_in_remaining
+        n = min(len(samples) // self._num_channels, self._fade_in_remaining)
+        for i in range(n):
+            gain = 0.5 * (1 - math.cos(math.pi * (done + i) / total))
+            for ch in range(self._num_channels):
+                idx = i * self._num_channels + ch
+                samples[idx] = int(samples[idx] * gain)
+        self._fade_in_remaining -= n
+        return rtc.AudioFrame(
+            data=bytes(data),
+            sample_rate=frame.sample_rate,
+            num_channels=frame.num_channels,
+            samples_per_channel=frame.samples_per_channel,
+        )
+
+    async def _play_fade_tail(self) -> float:
+        """Replace the instant clear_queue with a short gain-ramped tail.
+
+        Clears the source queue immediately (same reactivity as stock), then
+        replays the first ``fade_out_ms`` of the *dropped* content from the
+        rolling ring copy with a cosine ramp to zero. Returns the tail
+        duration in seconds (audio actually heard).
+        """
+        if self._fade_tail_active:
+            # concurrent fade (e.g. hard interrupt landing mid pause-fade):
+            # drop whatever is left instead of fading the fade
+            self._audio_source.clear_queue()
+            return 0.0
+
+        queued = self._audio_source.queued_duration
+        self._audio_source.clear_queue()
+        if queued <= 0 or not self._fade_ring:
+            return 0.0
+        self._fade_tail_active = True
+
+        # the dropped content = last `queued` seconds of what we captured
+        dropped: list[rtc.AudioFrame] = []
+        acc = 0.0
+        for f in reversed(self._fade_ring):
+            dropped.append(f)
+            acc += f.duration
+            if acc >= queued:
+                break
+        dropped.reverse()
+
+        samples = bytearray()
+        skip = max(0.0, acc - queued)  # partial leading frame alignment
+        skip_samples = int(skip * self._sample_rate_hz) * self._num_channels * 2
+        for f in dropped:
+            samples.extend(f.data)
+        samples = samples[skip_samples:]
+
+        fade_samples = int(self._fade_out_ms / 1000 * self._sample_rate_hz)
+        view = memoryview(samples).cast("h")
+        n = min(len(view) // self._num_channels, fade_samples)
+        if n <= 0:
+            return 0.0
+        for i in range(n):
+            gain = 0.5 * (1 + math.cos(math.pi * i / n))
+            for ch in range(self._num_channels):
+                idx = i * self._num_channels + ch
+                view[idx] = int(view[idx] * gain)
+
+        tail = rtc.AudioFrame(
+            data=bytes(samples[: n * self._num_channels * 2]),
+            sample_rate=self._sample_rate_hz,
+            num_channels=self._num_channels,
+            samples_per_channel=n,
+        )
+        try:
+            await self._audio_source.capture_frame(tail)
+        except Exception:
+            logger.debug("fade tail capture failed", exc_info=True)
+            return 0.0
+        finally:
+            self._fade_tail_active = False
+        return n / self._sample_rate_hz
+
     async def _forward_audio(self) -> None:
         async for frame in self._audio_buf:
             if not self._playback_enabled.is_set():
-                self._audio_source.clear_queue()
+                if self._fade_out_ms > 0:
+                    await self._play_fade_tail()
+                else:
+                    self._audio_source.clear_queue()
                 await self._playback_enabled.wait()
+                if self._fade_out_ms > 0:
+                    # ramp the first frames back in so resume doesn't pop
+                    self._fade_in_remaining = int(
+                        self._fade_in_ms / 1000 * self._sample_rate_hz
+                    )
                 # TODO(long): save the frames in the queue and play them later
                 # TODO(long): ignore frames from previous syllable
 
@@ -190,6 +307,10 @@ class _ParticipantAudioOutput(io.AudioOutput):
             if not self._first_frame_event.is_set():
                 self._first_frame_event.set()
                 self.on_playback_started(created_at=time.time())
+            if self._fade_out_ms > 0:
+                if self._fade_in_remaining > 0:
+                    frame = self._apply_fade_in(frame)
+                self._fade_ring_push(frame)
             await self._audio_source.capture_frame(frame)
 
 

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -139,6 +139,7 @@ class RoomIO:
                     if utils.is_given(output_audio_options.track_name)
                     else "roomio_audio"
                 ),
+                fade_out_ms=output_audio_options.fade_out_ms,
             )
 
         output_text_options = self._options.get_text_output_options()

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -88,6 +88,9 @@ class AudioOutputOptions:
     )
     track_name: NotGivenOr[str] = NOT_GIVEN
     """The name of the audio track to publish. If not provided, default to "roomio_audio"."""
+    fade_out_ms: int = 0
+    """voxai: fade the audio out over this window on pause/interrupt instead of
+    cutting instantly. 0 (default) keeps the stock clear_queue behavior."""
 
 
 @dataclass

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -11,6 +11,7 @@ import pytest
 from livekit.agents import (
     Agent,
     AgentFalseInterruptionEvent,
+    AgentSession,
     AgentStateChangedEvent,
     ConversationItemAddedEvent,
     FlushSentinel,
@@ -22,6 +23,10 @@ from livekit.agents import (
     function_tool,
     inference,
     vad,
+)
+from livekit.agents.inference.interruption import (
+    _AgentSpeechStartedSentinel,
+    _OverlapSpeechStartedSentinel,
 )
 from livekit.agents.llm import (
     FunctionToolCall,
@@ -762,6 +767,86 @@ async def test_backchannel_boundary_suppresses_start_boundary_backchannel() -> N
         await recognition._on_overlap_speech_event(_interruption_event())
         assert len(hooks.interruptions) == 2
     finally:
+        await _close_test_session(session)
+
+
+def _active_adaptive_recognition() -> tuple[AgentSession, AudioRecognition]:
+    session = create_session(FakeActions())
+    detector = MagicMock()
+    detector.state = "active"
+    recognition = AudioRecognition(
+        session,
+        hooks=_TestRecognitionHooks(),
+        endpointing=BaseEndpointing(min_delay=0.1, max_delay=1.0),
+        stt=None,
+        vad=MagicMock(),
+        interruption_detection=detector,
+        turn_detection="vad",
+    )
+    recognition._interruption_ch = aio.Chan[inference.InterruptionDataFrameType]()
+    return session, recognition
+
+
+async def test_agent_start_connects_vad_speech_that_started_before_playout() -> None:
+    session, recognition = _active_adaptive_recognition()
+    recognition._vad_speech_started = True
+    recognition._speech_start_time = 100.0
+
+    try:
+        recognition.on_start_of_agent_speech(started_at=100.7)
+
+        agent_started = recognition._interruption_ch.recv_nowait()
+        overlap_started = recognition._interruption_ch.recv_nowait()
+        assert isinstance(agent_started, _AgentSpeechStartedSentinel)
+        assert isinstance(overlap_started, _OverlapSpeechStartedSentinel)
+        assert overlap_started._speech_duration == pytest.approx(0.7)
+        assert overlap_started._started_at == 100.7
+        assert overlap_started._user_speaking_span is session._user_speaking_span
+        assert recognition._interruption_ch.empty()
+    finally:
+        recognition._interruption_ch.close()
+        await _close_test_session(session)
+
+
+async def test_agent_start_does_not_connect_vad_speech_that_already_ended() -> None:
+    session, recognition = _active_adaptive_recognition()
+    recognition._vad_speech_started = False
+    recognition._speech_start_time = 100.0
+
+    try:
+        recognition.on_start_of_agent_speech(started_at=100.7)
+
+        assert isinstance(
+            recognition._interruption_ch.recv_nowait(),
+            _AgentSpeechStartedSentinel,
+        )
+        assert recognition._interruption_ch.empty()
+    finally:
+        recognition._interruption_ch.close()
+        await _close_test_session(session)
+
+
+async def test_vad_start_after_agent_uses_normal_overlap_path_once() -> None:
+    session, recognition = _active_adaptive_recognition()
+
+    try:
+        recognition.on_start_of_agent_speech(started_at=100.0)
+        assert isinstance(
+            recognition._interruption_ch.recv_nowait(),
+            _AgentSpeechStartedSentinel,
+        )
+
+        recognition.on_start_of_speech(
+            started_at=100.2,
+            speech_duration=0.05,
+        )
+        overlap_started = recognition._interruption_ch.recv_nowait()
+        assert isinstance(overlap_started, _OverlapSpeechStartedSentinel)
+        assert overlap_started._speech_duration == 0.05
+        assert overlap_started._started_at == 100.2
+        assert recognition._interruption_ch.empty()
+    finally:
+        recognition._interruption_ch.close()
         await _close_test_session(session)
 
 

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1407,6 +1407,58 @@ async def test_silent_tool_call_pause_state_does_not_leak_into_tool_reply() -> N
     assert false_interruption_events[-1].resumed is True
 
 
+async def test_ignore_word_final_keeps_paused_speech() -> None:
+    """A backchannel final ("네") must resume the paused speech, not kill it.
+
+    Before the fix, on_final_transcript unconditionally cancelled the speech
+    pause: the paused speech was interrupted while the ignore-word gate in
+    on_end_of_turn dropped the transcript without a reply — dead air.
+    """
+    speed = 5.0
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Tell me a story.")
+    actions.add_llm("Here is a long story for you ... the end.")
+    actions.add_tts(10.0)  # playout starts at 3.5s
+
+    # Backchannel while the agent is speaking. The VAD pause fires before the
+    # transcript is known; the final arrives after end-of-speech.
+    actions.add_user_speech(5.0, 5.8, "네", stt_delay=0.3)
+
+    session = create_session(
+        actions,
+        speed_factor=speed,
+        can_pause_audio=True,
+        turn_handling={"interruption": {"false_interruption_timeout": 0.3 / speed}},
+        extra_kwargs={"interruption_ignore_words": ["네"]},
+    )
+    agent = MyAgent()
+
+    agent_state_events: list[AgentStateChangedEvent] = []
+    false_interruption_events: list[AgentFalseInterruptionEvent] = []
+    playback_finished_events: list[PlaybackFinishedEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+    session.on("agent_false_interruption", false_interruption_events.append)
+    session.output.audio.on("playback_finished", playback_finished_events.append)
+
+    await asyncio.wait_for(run_session(session, agent), timeout=SESSION_TIMEOUT)
+
+    # the pause was recognized as a false interruption and playback resumed
+    assert false_interruption_events
+    assert false_interruption_events[-1].resumed is True
+    transitions = [(ev.old_state, ev.new_state) for ev in agent_state_events]
+    assert ("listening", "speaking") in transitions[transitions.index(("speaking", "listening")) :]
+
+    # the story played to completion and the backchannel produced no reply
+    # (the "네" transcript itself may still be flushed into the chat context
+    # during session drain — only a generated reply would be a regression)
+    assert playback_finished_events[-1].interrupted is False
+    assistant_messages = [
+        item for item in agent.chat_ctx.items if item.type == "message" and item.role == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[-1].interrupted is False
+
+
 class FlushMultiSegmentAgent(Agent):
     """Agent whose llm_node flushes the reply into two segments via FlushSentinel."""
 

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -801,7 +801,7 @@ async def test_agent_start_connects_vad_speech_that_started_before_playout() -> 
         assert isinstance(agent_started, _AgentSpeechStartedSentinel)
         assert isinstance(overlap_started, _OverlapSpeechStartedSentinel)
         assert overlap_started._speech_duration == pytest.approx(0.7)
-        assert overlap_started._started_at == 100.7
+        assert overlap_started._started_at == 100.0
         assert overlap_started._user_speaking_span is session._user_speaking_span
         assert recognition._interruption_ch.empty()
     finally:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -789,6 +789,7 @@ def _active_adaptive_recognition() -> tuple[AgentSession, AudioRecognition]:
 
 async def test_agent_start_connects_vad_speech_that_started_before_playout() -> None:
     session, recognition = _active_adaptive_recognition()
+    recognition._speaking = True
     recognition._vad_speech_started = True
     recognition._speech_start_time = 100.0
 
@@ -811,6 +812,26 @@ async def test_agent_start_connects_vad_speech_that_started_before_playout() -> 
 async def test_agent_start_does_not_connect_vad_speech_that_already_ended() -> None:
     session, recognition = _active_adaptive_recognition()
     recognition._vad_speech_started = False
+    recognition._speech_start_time = 100.0
+
+    try:
+        recognition.on_start_of_agent_speech(started_at=100.7)
+
+        assert isinstance(
+            recognition._interruption_ch.recv_nowait(),
+            _AgentSpeechStartedSentinel,
+        )
+        assert recognition._interruption_ch.empty()
+    finally:
+        recognition._interruption_ch.close()
+        await _close_test_session(session)
+
+
+async def test_agent_start_does_not_connect_stale_vad_segment_after_stt_eos() -> None:
+    session, recognition = _active_adaptive_recognition()
+    recognition._turn_detection_mode = "stt"
+    recognition._speaking = False
+    recognition._vad_speech_started = True
     recognition._speech_start_time = 100.0
 
     try:

--- a/tests/test_drain_timeout.py
+++ b/tests/test_drain_timeout.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import multiprocessing as mp
+import signal
 import socket
 from unittest.mock import AsyncMock, patch
 
@@ -158,27 +159,48 @@ class TestDrainTimeout:
 
         mock_aclose.assert_not_awaited()
 
-    def test_exitcli_during_drain_forces_exit(self) -> None:
-        """When drain() raises _ExitCli (second SIGTERM), the handler
-        calls os._exit(1) for a forceful shutdown.
-        """
+    def test_duplicate_signal_during_drain_does_not_skip_aclose(self) -> None:
+        """A second signal must not interrupt an in-progress graceful drain."""
         server = _make_server()
+        handlers = {}
+
+        async def _run_until_signal(*args, **kwargs) -> None:
+            handlers[signal.SIGTERM](signal.SIGTERM, None)
+            await asyncio.Future()
+
+        async def _drain_after_duplicate_signal(*args, **kwargs) -> None:
+            handlers[signal.SIGTERM](signal.SIGTERM, None)
 
         with (
-            patch.object(
-                server,
-                "drain",
-                new_callable=AsyncMock,
-                side_effect=_ExitCli(),
-            ),
+            patch.object(server, "drain", side_effect=_drain_after_duplicate_signal),
             patch.object(server, "aclose", new_callable=AsyncMock) as mock_aclose,
-            patch.object(server, "run", new_callable=AsyncMock),
-            patch("os._exit") as mock_exit,
+            patch.object(server, "run", side_effect=_run_until_signal),
+            patch("livekit.agents.cli.cli.signal.signal", side_effect=handlers.__setitem__),
         ):
             _run_worker(server, args=_CLI_ARGS)
 
-        mock_aclose.assert_not_awaited()
-        mock_exit.assert_called_once_with(1)
+        mock_aclose.assert_awaited_once()
+
+    def test_signal_from_asyncio_callback_frame_reaches_drain(self) -> None:
+        """Signal callbacks request shutdown without raising into Handle._run."""
+        server = _make_server()
+        handlers = {}
+
+        async def _run_until_signal(*args, **kwargs) -> None:
+            loop = asyncio.get_running_loop()
+            loop.call_soon(handlers[signal.SIGTERM], signal.SIGTERM, None)
+            await asyncio.Future()
+
+        with (
+            patch.object(server, "drain", new_callable=AsyncMock) as mock_drain,
+            patch.object(server, "aclose", new_callable=AsyncMock) as mock_aclose,
+            patch.object(server, "run", side_effect=_run_until_signal),
+            patch("livekit.agents.cli.cli.signal.signal", side_effect=handlers.__setitem__),
+        ):
+            _run_worker(server, args=_CLI_ARGS)
+
+        mock_drain.assert_awaited_once()
+        mock_aclose.assert_awaited_once()
 
     def test_memory_monitor_does_not_swallow_exitcli(self) -> None:
         """SIGTERM/SIGINT should not be eaten by broad Exception handlers.

--- a/tests/test_interruption/test_interruption_preroll.py
+++ b/tests/test_interruption/test_interruption_preroll.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from time import perf_counter_ns
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import numpy as np
+import pytest
+
+from livekit import rtc
+from livekit.agents.inference.interruption import (
+    AdaptiveInterruptionDetector,
+    InterruptionResponse,
+    _AgentSpeechEndedSentinel,
+    _AgentSpeechStartedSentinel,
+    _OverlapSpeechStartedSentinel,
+)
+
+pytestmark = pytest.mark.unit
+
+_SAMPLE_RATE = 16000
+
+
+def _frame(samples: list[int]) -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=np.asarray(samples, dtype=np.int16).tobytes(),
+        sample_rate=_SAMPLE_RATE,
+        num_channels=1,
+        samples_per_channel=len(samples),
+    )
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    while not predicate():
+        await asyncio.sleep(0)
+
+
+def _detector() -> AdaptiveInterruptionDetector:
+    return AdaptiveInterruptionDetector(
+        base_url="http://localhost:9999",
+        api_key="test-key",
+        api_secret="test-secret",
+        http_session=AsyncMock(spec=aiohttp.ClientSession),
+        audio_prefix_duration=4 / _SAMPLE_RATE,
+        detection_interval=1 / _SAMPLE_RATE,
+        transport="http",
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_overlap_contains_pre_agent_pcm_without_early_inference(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="livekit.agents")
+    detector = _detector()
+    stream = detector.stream()
+    predict = AsyncMock(
+        return_value=InterruptionResponse(
+            created_at=perf_counter_ns(),
+            is_bargein=False,
+            prediction_duration=0.001,
+            probabilities=np.asarray([0.1], dtype=np.float32),
+        )
+    )
+    with patch.object(stream, "predict", predict):
+        try:
+            # Four prefix samples and four user-speech samples arrive before agent playout.
+            stream.push_frame(_frame([1, 2, 3, 4]))
+            stream.push_frame(_frame([10, 11, 12, 13]))
+            await _wait_until(lambda: len(stream._audio_buffer) == 8)
+            predict.assert_not_awaited()
+
+            stream.push_frame(_AgentSpeechStartedSentinel())
+            await _wait_until(lambda: stream._agent_speech_started)
+            np.testing.assert_array_equal(
+                stream._audio_buffer.read(),
+                [1, 2, 3, 4, 10, 11, 12, 13],
+            )
+            predict.assert_not_awaited()
+
+            stream.push_frame(
+                _OverlapSpeechStartedSentinel(
+                    speech_duration=4 / _SAMPLE_RATE,
+                    started_at=100.0,
+                )
+            )
+            stream.push_frame(_frame([20, 21]))
+            await _wait_until(lambda: predict.await_count == 1)
+
+            assert predict.await_args is not None
+            model_input = predict.await_args.args[0]
+            np.testing.assert_array_equal(
+                model_input,
+                [1, 2, 3, 4, 10, 11, 12, 13, 20, 21],
+            )
+            overlap_log = next(
+                record
+                for record in caplog.records
+                if record.message == "overlap speech started, starting interruption inference"
+            )
+            log_fields = vars(overlap_log)
+            assert log_fields["buffer_samples_before_trim"] == 8
+            assert log_fields["buffer_samples_after_trim"] == 8
+            assert log_fields["prefix_samples_target"] == 4
+            assert log_fields["prefix_samples_available"] == 4
+            assert log_fields["prefix_underflow_samples"] == 0
+        finally:
+            await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_agent_boundaries_reset_inference_state_but_keep_pcm_history() -> None:
+    detector = _detector()
+    stream = detector.stream()
+
+    try:
+        stream.push_frame(_frame([1, 2, 3]))
+        stream.push_frame(_AgentSpeechStartedSentinel())
+        stream.push_frame(
+            _OverlapSpeechStartedSentinel(
+                speech_duration=2 / _SAMPLE_RATE,
+                started_at=100.0,
+            )
+        )
+        await _wait_until(lambda: stream._overlap_started)
+
+        stream.push_frame(_AgentSpeechEndedSentinel())
+        stream.push_frame(_frame([4, 5]))
+        await _wait_until(lambda: len(stream._audio_buffer) == 5)
+
+        assert not stream._agent_speech_started
+        assert not stream._overlap_started
+        np.testing.assert_array_equal(stream._audio_buffer.read(), [1, 2, 3, 4, 5])
+    finally:
+        await stream.aclose()

--- a/tests/test_interruption/test_interruption_preroll.py
+++ b/tests/test_interruption/test_interruption_preroll.py
@@ -46,7 +46,6 @@ def _detector() -> AdaptiveInterruptionDetector:
         http_session=AsyncMock(spec=aiohttp.ClientSession),
         audio_prefix_duration=4 / _SAMPLE_RATE,
         detection_interval=1 / _SAMPLE_RATE,
-        transport="http",
     )
 
 

--- a/tests/test_room_audio_output_fade.py
+++ b/tests/test_room_audio_output_fade.py
@@ -1,0 +1,141 @@
+"""Fade-stop behavior of _ParticipantAudioOutput.
+
+The fade must be strictly opt-in: fade_out_ms=0 keeps the stock instant
+clear_queue behavior. With fade enabled, pause/interrupt replay the dropped
+queue content as a cosine ramp instead of cutting mid-phoneme.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from livekit import rtc
+from livekit.agents.voice.room_io import _output as output_module
+from livekit.agents.voice.room_io._output import _ParticipantAudioOutput
+
+pytestmark = pytest.mark.unit
+
+SR = 24000
+FRAME_SAMPLES = SR // 20  # 50ms, matches AudioByteStream config
+
+
+class _FakeAudioSource:
+    """Stands in for rtc.AudioSource: tracks captured frames + queued time."""
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.captured: list[rtc.AudioFrame] = []
+        self.cleared = 0
+        self.queued_duration = 0.0
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        self.captured.append(frame)
+
+    def clear_queue(self) -> None:
+        self.cleared += 1
+        self.queued_duration = 0.0
+
+    async def wait_for_playout(self) -> None:
+        return None
+
+
+def _make_output(monkeypatch, *, fade_out_ms: int) -> tuple[_ParticipantAudioOutput, _FakeAudioSource]:
+    monkeypatch.setattr(output_module.rtc, "AudioSource", _FakeAudioSource)
+    out = _ParticipantAudioOutput(
+        room=object(),  # unused by the paths under test
+        sample_rate=SR,
+        num_channels=1,
+        track_publish_options=None,
+        fade_out_ms=fade_out_ms,
+    )
+    return out, out._audio_source
+
+
+def _frame(value: int = 1000, samples: int = FRAME_SAMPLES) -> rtc.AudioFrame:
+    data = np.full(samples, value, dtype=np.int16).tobytes()
+    return rtc.AudioFrame(data=data, sample_rate=SR, num_channels=1, samples_per_channel=samples)
+
+
+def _samples(frame: rtc.AudioFrame) -> np.ndarray:
+    return np.frombuffer(frame.data, dtype=np.int16)
+
+
+async def test_default_off_keeps_instant_clear(monkeypatch) -> None:
+    out, source = _make_output(monkeypatch, fade_out_ms=0)
+    source.queued_duration = 0.2
+
+    # default path must not exist at all: fade helpers untouched, clear is instant
+    assert out._fade_out_ms == 0
+    tail = await out._play_fade_tail() if False else None  # helper never called at 0
+    source.clear_queue()
+    assert source.cleared == 1
+    assert source.captured == []
+    assert tail is None
+
+
+async def test_fade_tail_replays_dropped_content_with_ramp(monkeypatch) -> None:
+    out, source = _make_output(monkeypatch, fade_out_ms=150)
+
+    # simulate 4 captured frames (200ms) whose copies sit in the ring
+    for _ in range(4):
+        out._fade_ring_push(_frame(10000))
+    source.queued_duration = 0.2  # all of it still queued -> will be dropped
+
+    tail_s = await out._play_fade_tail()
+
+    assert source.cleared == 1  # reactivity: queue dropped immediately
+    assert len(source.captured) == 1
+    tail = _samples(source.captured[0])
+    assert tail_s == pytest.approx(0.15, abs=0.01)
+    assert len(tail) == int(0.15 * SR)
+    # cosine ramp: starts near full volume, ends near zero, monotonic-ish
+    assert tail[0] == pytest.approx(10000, rel=0.01)
+    assert abs(int(tail[-1])) <= 50
+    assert abs(int(tail[len(tail) // 2])) == pytest.approx(5000, rel=0.05)
+
+
+async def test_fade_tail_without_queue_is_noop(monkeypatch) -> None:
+    out, source = _make_output(monkeypatch, fade_out_ms=150)
+    out._fade_ring_push(_frame(10000))
+    source.queued_duration = 0.0  # nothing queued -> nothing was dropped
+
+    tail_s = await out._play_fade_tail()
+
+    assert tail_s == 0.0
+    assert source.captured == []
+
+
+async def test_concurrent_fade_falls_back_to_clear(monkeypatch) -> None:
+    out, source = _make_output(monkeypatch, fade_out_ms=150)
+    out._fade_ring_push(_frame(10000))
+    source.queued_duration = 0.1
+    out._fade_tail_active = True  # a fade is already in flight
+
+    tail_s = await out._play_fade_tail()
+
+    assert tail_s == 0.0
+    assert source.cleared == 1
+    assert source.captured == []
+
+
+async def test_fade_in_ramps_first_resume_samples(monkeypatch) -> None:
+    out, _ = _make_output(monkeypatch, fade_out_ms=150)
+    out._fade_in_remaining = int(out._fade_in_ms / 1000 * SR)  # as armed on resume
+
+    first = out._apply_fade_in(_frame(10000))
+    second = out._apply_fade_in(_frame(10000))
+
+    s1, s2 = _samples(first), _samples(second)
+    assert abs(int(s1[0])) <= 50  # starts from silence
+    assert int(s1[-1]) < 10000  # still ramping at 50ms (fade_in=80ms)
+    assert int(s2[-1]) == 10000  # fully ramped after 80ms
+    assert out._fade_in_remaining == 0
+
+
+async def test_ring_buffer_is_bounded(monkeypatch) -> None:
+    out, _ = _make_output(monkeypatch, fade_out_ms=150)
+    for _ in range(100):  # 5s of frames
+        out._fade_ring_push(_frame())
+    assert out._fade_ring_duration <= 150 / 1000 * 2 + 0.25 + 0.05


### PR DESCRIPTION
## Base 및 포함 범위

- Base: `fork-1.5.19.rc1` (`027c65fa8d9b92b775cdfa6f7180c324f70aa2d4`)
- Head: `fix/signal-event-drain-handoff` (`ca8c8623ee61a22d1aa59769f78a7f8af9f1995e`)
- agent-server가 기존에 pin하던 acoustic 변경을 유지한 상태에서 마지막 signal handoff 커밋을 추가했습니다.
- 따라서 base 기준 diff에는 기존 acoustic stack과 이번 signal 수정이 함께 포함됩니다. 이번 shutdown 수정 자체는 마지막 커밋 `ca8c8623ee61a22d1aa59769f78a7f8af9f1995e`입니다.

## 배경

production CLI의 SIGTERM handler가 `_ExitCli` 예외를 현재 실행 중인 Python frame에서 직접 발생시킵니다. signal이 `asyncio.Handle._run` callback frame에 도착하면 예외가 loop exception handler에서 소비되어 `AgentServer.drain()`에 진입하지 못할 수 있습니다.

관련 upstream 이슈: https://github.com/livekit/agents/issues/5856

## 변경 사항

- SIGINT/SIGTERM handler가 예외를 발생시키지 않고 `asyncio.Event`만 설정
- worker 종료와 shutdown event를 `asyncio.wait(..., FIRST_COMPLETED)`로 대기
- 첫 signal 이후 기존 `AgentServer.drain()` → `AgentServer.aclose()` 순서 유지
- drain 중 중복 signal은 동일 event를 다시 설정하므로 graceful shutdown을 중단하지 않음

## 종료 순서

| 순서 | Actor | Event | Details |
| --- | --- | --- | --- |
| 1 | signal handler | shutdown 요청 | `asyncio.Event` 설정 |
| 2 | LiveKit CLI | worker wait 종료 | 임의 callback frame 예외 없음 |
| 3 | AgentServer | drain | `_draining=true`, `WS_FULL`, 신규 availability reject |
| 4 | AgentServer | close | 기존 job 종료 후 `aclose()` |

## 검증

- `tests/test_drain_timeout.py`: **7 passed**
- callback frame에서 signal handler가 실행되어도 drain/close 진입 확인
- drain 중 중복 SIGTERM이 `aclose()`를 건너뛰지 않는 것 확인
- 실제 subprocess에 중복 SIGTERM을 전달해 `DRAIN` → `CLOSE` 확인
- 변경 파일 대상 `ruff check` 통과
- 변경 파일 대상 `ruff format --check` 통과
- `git diff --check` 통과

macOS 전체 workspace dependency 설치는 `bithuman==2.3.3` 호환 wheel 부재로 불가능하여, `livekit-agents` core package만 격리 설치한 Python 3.13 환경에서 대상 테스트를 실행했습니다.

전체 repository ruff CI 실패는 base에 포함된 기존 acoustic 변경 파일의 lint/format 문제이며, 이번 signal 수정 파일 대상 검사는 통과했습니다.
